### PR TITLE
Fix/send simple nft

### DIFF
--- a/src/components/collectibles/SLPCollectibleDetail.vue
+++ b/src/components/collectibles/SLPCollectibleDetail.vue
@@ -61,11 +61,13 @@ export default {
       openURL(url)
     },
     send () {
+      const isSimpleNft = this.collectible.type === 1
       this.$router.push({
         name: 'transaction-send',
         query: {
           assetId: 'slp/' + this.collectible.token_id,
-          tokenType: 65,
+          tokenType: isSimpleNft ? 1 : 65,
+          simpleNft: isSimpleNft,
           amount: 1,
           symbol: this.collectible.symbol,
           image: this.imageUrl,

--- a/src/pages/apps/gifts/index.vue
+++ b/src/pages/apps/gifts/index.vue
@@ -37,7 +37,7 @@
                   :index="recordType"
                   clickable v-close-popup
                   :active="recordType === filterOpts.recordType.active"
-                  @click="() => fetchGifts({ recordType: recordType })"
+                  @click="() => fetchGifts({ recordType: recordType, limit: 10 })"
                 >
                   <q-item-section>
                     <q-item-label>{{ capitalize(recordType) }}</q-item-label>

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -365,6 +365,11 @@ export default {
       required: false,
       default: 1
     },
+    simpleNft: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
     symbol: {
       type: String,
       required: false
@@ -481,6 +486,7 @@ export default {
     },
     isNFT () {
       if (this.isSep20 && erc721IdRegexp.test(this.assetId)) return true
+      if (this.tokenType === 1 && this.simpleNft) return true
 
       return this.tokenType === 65
     },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -33,6 +33,8 @@ const routes = [
           if (!isNaN(props.amount)) props.amount = Number(props.amount)
           if (props.fixed === 'true') props.fixed = true
           else if (props.fixed === 'false') props.fixed = false
+          if (props.simpleNft === 'true') props.simpleNft = true
+          else if (props.simpleNft === 'false') props.simpleNft = false
           return props
         },
         component: () => import('pages/transaction/send.vue')


### PR DESCRIPTION
- fix insufficient balance error when sending simple nfts
- other: pagination not used when list is refreshed from filter dropdown in gifts list page