### PR TITLE
Improvements/send page

### DIFF
--- a/src/components/SendPageForm.vue
+++ b/src/components/SendPageForm.vue
@@ -33,6 +33,13 @@
       />
     </div>
   </div>
+  <div
+    v-if="isLegacyAddress"
+    style="border: 2px solid orange;"
+    class="q-mx-md q-mb-md q-pa-sm text-center text-body2 text-bow"
+    :class="getDarkModeClass(darkMode)"
+    v-html="$t('LegacyAddressWarning')"
+  />
 
   <template v-if="$store.state.global.online !== false">
     <div class="row" v-if="!isNFT">
@@ -184,22 +191,22 @@ export default {
 
   data () {
     return {
-      // recipientAddress: '',
       amount: 0,
       amountFormatted: 0,
       sendAmountInFiat: 0,
       balanceExceeded: false,
       emptyRecipient: false,
-      selectedDenomination: 'BCH'
+      selectedDenomination: 'BCH',
+      isLegacyAddress: false
     }
   },
 
   mounted () {
-    // this.recipientAddress = this.recipient.recipientAddress
     this.amount = this.recipient.amount
     this.amountFormatted = this.inputExtras.amountFormatted
     this.sendAmountInFiat = this.inputExtras.sendAmountInFiat
     this.selectedDenomination = this.denomination
+    this.isLegacyAddress = this.inputExtras.isLegacyAddress
   },
 
   computed: {

--- a/src/i18n/de/index.js
+++ b/src/i18n/de/index.js
@@ -327,6 +327,7 @@ export default {
   Language: "Sprache",
   LeavingPage: "Seite verlassen",
   LegacyAddress: "Legacy -Adresse",
+  LegacyAddressWarning: "Sie haben eine Legacy -Adresse eingefügt.Bitte stellen Sie sicher, dass es sich um eine <span class = \"highlighted-word\"> BCH-Einzahlungsadresse </span> handelt, keine BTC-Einzahlungsadresse.",
   Leverage: "Hebelwirkung",
   LightMode: "Lichtmodus",
   Link: "Verknüpfung",

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -327,6 +327,7 @@ export default {
   Language: "Language",
   LeavingPage: "Leaving page",
   LegacyAddress: "Legacy Address",
+  LegacyAddressWarning: "You pasted a legacy address. Please make sure that it is a <span class=\"highlighted-word\">BCH deposit address</span>, not a BTC deposit address.",
   Leverage: "Leverage",
   LightMode: "Light Mode",
   Link: "Link",

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -327,6 +327,7 @@ export default {
   Language: "Idioma",
   LeavingPage: "Página de salida",
   LegacyAddress: "Dirección heredada",
+  LegacyAddressWarning: "Pegó una dirección heredada.Asegúrese de que sea una dirección de depósito <span class = \"highlighted-word\"> BCH de depósito </span>, no una dirección de depósito BTC.",
   Leverage: "Aprovechar",
   LightMode: "Modo de luz",
   Link: "Enlace",

--- a/src/i18n/translate.js
+++ b/src/i18n/translate.js
@@ -866,7 +866,8 @@ const additional = [
     ReceiverWarningText2: "backup your seed phrase",
     ReceiverWarningText3: "before proceeding.",
     GoBack: "Go back",
-    Proceed: "Proceed"
+    Proceed: "Proceed",
+    LegacyAddressWarning: 'You pasted a legacy address. Please make sure that it is a <span class="highlighted-word">BCH deposit address</span>, not a BTC deposit address.'
   }
 ]
 

--- a/src/i18n/zh-cn/index.js
+++ b/src/i18n/zh-cn/index.js
@@ -327,6 +327,7 @@ export default {
   Language: "语言",
   LeavingPage: "离开页面",
   LegacyAddress: "遗产地址",
+  LegacyAddressWarning: "您粘贴了一个遗产地址。请确保它是<span class = \"highlighted-word\"> BCH存款地址</span>而不是BTC存款地址。",
   Leverage: "杠杆作用",
   LightMode: "光模式",
   Link: "关联",

--- a/src/i18n/zh-tw/index.js
+++ b/src/i18n/zh-tw/index.js
@@ -327,6 +327,7 @@ export default {
   Language: "語言",
   LeavingPage: "離開頁面",
   LegacyAddress: "遺產地址",
+  LegacyAddressWarning: "您粘貼了一個遺產地址。請確保它是<span class = \"highlighted-word\"> BCH存款地址</span>而不是BTC存款地址。",
   Leverage: "槓桿作用",
   LightMode: "光模式",
   Link: "關聯",

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -68,6 +68,13 @@
                   </template>
                 </q-input>
               </div>
+              <div
+                v-if="isLegacyAddress"
+                style="border: 2px solid orange;"
+                class="q-mx-md q-mb-md q-pa-sm text-center text-subtitle1 text-bow"
+                :class="getDarkModeClass(darkMode)"
+                v-html="$t('LegacyAddressWarning')"
+              />
               <div class="col-12 text-uppercase text-center or-label">
                 {{ $t('or') }}
               </div>
@@ -457,7 +464,8 @@ export default {
         setMax: false,
         emptyRecipient: false,
         selectedDenomination: 'BCH',
-        isBip21: false
+        isBip21: false,
+        isLegacyAddress: false
       }],
 
       sent: false,
@@ -487,7 +495,8 @@ export default {
       currentActiveRecipientIndex: 0,
       totalAmountSent: 0,
       totalFiatAmountSent: 0,
-      currentWalletBalance: 0
+      currentWalletBalance: 0,
+      isLegacyAddress: false
     }
   },
 
@@ -612,6 +621,10 @@ export default {
         this.inputExtras[this.currentActiveRecipientIndex].amountFormatted = finalAmount
         this.sendDataMultiple[this.currentActiveRecipientIndex].amount = finalAmount
       }
+    },
+    manualAddress (address) {
+      this.isLegacyAddress = new Address(address).isLegacyAddress()
+      this.inputExtras[this.currentActiveRecipientIndex].isLegacyAddress = this.isLegacyAddress
     }
   },
 
@@ -1391,7 +1404,8 @@ export default {
           setMax: false,
           emptyRecipient: true,
           selectedDenomination: 'BCH',
-          isBip21: false
+          isBip21: false,
+          isLegacyAddress: false
         })
         for (let i = 1; i <= recipientsLength; i++) {
           this.expandedItems[`R${i}`] = false
@@ -1489,6 +1503,7 @@ export default {
     onRecipientInput (value) {
       this.sendDataMultiple[this.currentActiveRecipientIndex].recipientAddress = value
       this.inputExtras[this.currentActiveRecipientIndex].emptyRecipient = value === ''
+      this.inputExtras[this.currentActiveRecipientIndex].isLegacyAddress = new Address(value).isLegacyAddress()
     },
     onEmptyRecipient (value) {
       this.inputExtras[this.currentActiveRecipientIndex].emptyRecipient = value
@@ -1648,7 +1663,6 @@ export default {
       font-size: 16px;
       margin-top: 20px;
     }
-    
     .view-explorer-button {
       text-decoration: none;
     }
@@ -1657,5 +1671,9 @@ export default {
       border: 1px solid grey;
       background-color: inherit;
     }
+  }
+  .highlighted-word {
+    font-weight: bold;
+    color: orange;
   }
 </style>

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -172,7 +172,7 @@
               <div
                 class="row"
                 style="margin-top: -10px;"
-                v-if="!sendDataMultiple[0].fixedAmount && !isNFT && !setAmountInFiat && asset.id === 'bch'"
+                v-if="!sendDataMultiple[0].fixedAmount && !isNFT && asset.id === 'bch'"
               >
                 <div class="col q-mt-md">
                   <a
@@ -181,7 +181,10 @@
                     :class="getDarkModeClass(darkMode)"
                     @click.prevent="onSetAmountToFiatClick"
                   >
-                    {{ `${$t('SetAmountIn')} ${String(currentSendPageCurrency()).toUpperCase()}` }}
+                    {{ `
+                      ${$t('SetAmountIn')}
+                      ${setAmountInFiat ? selectedDenomination : String(currentSendPageCurrency()).toUpperCase()}
+                    ` }}
                   </a>
                 </div>
               </div>
@@ -1434,7 +1437,7 @@ export default {
       this.showQrScanner = value
     },
     onSetAmountToFiatClick () {
-      this.setAmountInFiat = true
+      this.setAmountInFiat = !this.setAmountInFiat
       this.sliderStatus = false
       this.sendDataMultiple.forEach((data) => {
         data.amount = 0

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -84,7 +84,7 @@
                   size="lg"
                   class="btn-scan button text-white bg-grad"
                   icon="mdi-qrcode"
-                  @click.once="showQrScanner = true"
+                  @click="showQrScanner = true"
                 />
               </div>
             </div>


### PR DESCRIPTION
- if a legacy address is pasted, a warning is now displayed to remind users to make sure that the address they pasted is a BCH deposit address and not a BTC deposit address
- added a way to switch back to to setting BCH amount after selecting set to fiat amount
- fixed QR scanner button in send page not clickable when scanning fails for the first time