### PR TITLE
Fix/wallet backup and scan qr

### DIFF
--- a/src/components/qr-scanner.vue
+++ b/src/components/qr-scanner.vue
@@ -92,6 +92,7 @@ export default {
   methods: {
     stopScan () {
       this.$emit('input', false)
+      this.$emit('update:model-value', false)
       BarcodeScanner.showBackground()
       BarcodeScanner.stopScan()
       this.adjustComponentsClasslist(false)

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -245,7 +245,7 @@ export default {
           this.submitLabel = 'Processing'
           this.customKeyboardState = 'dismiss'
           setTimeout(() => {
-            this.toggleMnemonicDisplay()
+            this.toggleMnemonicDisplay('proceed')
           }, 1000)
         },
         (error) => {


### PR DESCRIPTION
- fixed user not proceeding to Wallet Backup app after biometric authentication success
- fixed scanner not re-opening after exiting by clicking the 'x' button