### PR TITLE
Improvements/cash in

### DIFF
--- a/src/components/cash-in/SelectPaymentType.vue
+++ b/src/components/cash-in/SelectPaymentType.vue
@@ -41,14 +41,15 @@ export default {
     return {
       darkMode: this.$store.getters['darkmode/getStatus'],
       selectedCurrency: this.$store.getters['market/selectedCurrency'],
-      currencyOpts: [],
+      // currencyOpts: [],
       openCurrencyDialog: false
     }
   },
   emits: ['select-payment', 'select-currency'],
   props: {
     options: Array,
-    fiat: Object
+    fiat: Object,
+    fiatOption: Array
   },
   watch: {
     selectedCurrency (value) {
@@ -56,7 +57,6 @@ export default {
     }
   },
   mounted () {
-    this.fetchFiatCurrencies()
     this.selectedCurrency = this.fiat
   },
   methods: {
@@ -65,7 +65,7 @@ export default {
       this.$q.dialog({
         component: CurrencyFilterDialog,
         componentProps: {
-          fiatList: this.currencyOpts
+          fiatList: this.fiatOption
         }
       })
         .onOk(currency => {
@@ -74,25 +74,6 @@ export default {
     },
     selectPaymentType (value) {
       this.$emit('select-payment', value)
-    },
-    async fetchFiatCurrencies () {
-      const vm = this
-      await backend.get('/ramp-p2p/currency/fiat')
-        .then(response => {
-          vm.currencyOpts = response.data
-        })
-        .catch(error => {
-          console.error(error)
-          if (error.response) {
-            console.error(error.response)
-            if (error.response.status === 403) {
-              // bus.emit('session-expired')
-              console.log('session-expired')
-            }
-          } else {
-            bus.emit('network-error')
-          }
-        })
     }
   }
 }

--- a/src/components/cash-in/SelectPaymentType.vue
+++ b/src/components/cash-in/SelectPaymentType.vue
@@ -9,7 +9,7 @@
 
     <div class="text-center q-pt-md" v-if="options.length === 0">
       <q-img class="vertical-top q-my-md" src="empty-wallet.svg" style="width: 75px; fill: gray;" />
-      <p style="font-size: medium;">No Payment Type<br>Available... ☹</p>
+      <p style="font-size: medium;">No ads available ☹ <br>Please try again later</p>
     </div>
     <q-card flat bordered class="q-mt-sm q-mx-md pt-card-2 text-bow" :class="getDarkModeClass(darkMode)" v-else>
       <q-virtual-scroll :items="options" style="max-height: 40vh;">

--- a/src/components/cash-in/index.vue
+++ b/src/components/cash-in/index.vue
@@ -37,6 +37,7 @@
             :key="selectPaymentTypeKey"
             :options="paymentTypeOpts"
             :fiat="selectedCurrency"
+            :fiat-option="fiatCurrencies"
             @select-currency="setCurrency"
             @select-payment="setPaymentType"
             @update-fiat="updateSelectedCurrency"
@@ -97,6 +98,9 @@ export default {
     OrderList,
     NetworkError
   },
+  props: {
+    fiatCurrencies: Array
+  },
   data () {
     return {
       darkMode: this.$store.getters['darkmode/getStatus'],
@@ -118,7 +122,7 @@ export default {
       register: false,
       openorderList: false,
       loading: true,
-      fiatCurrencies: null,
+      // fiatCurrencies: null,
       order: null,
       orderPayload: null,
       openOrderPage: false,
@@ -246,18 +250,18 @@ export default {
       this.loading = false
       if (nextStep) this.step++
     },
-    fetchFiatCurrencies () {
-      const vm = this
-      backend.get('/ramp-p2p/currency/fiat', { authorize: true })
-        .then(response => {
-          vm.fiatCurrencies = response.data
-        })
-        .catch(error => {
-          console.error(error)
-          // this.state = 'network-error'
-          this.dislayNetworkError()
-        })
-    },
+    // fetchFiatCurrencies () {
+    //   const vm = this
+    //   backend.get('/ramp-p2p/currency/fiat', { authorize: true })
+    //     .then(response => {
+    //       vm.fiatCurrencies = response.data
+    //     })
+    //     .catch(error => {
+    //       console.error(error)
+    //       // this.state = 'network-error'
+    //       this.dislayNetworkError()
+    //     })
+    // },
     updateSelectedCurrency (currency) {
       this.selectedCurrency = currency
       this.fetchCashinAds()

--- a/src/components/cash-in/order.vue
+++ b/src/components/cash-in/order.vue
@@ -71,7 +71,7 @@ export default {
   data () {
     return {
       state: 'await_status',
-      statusTitle: 'Processing transaction',
+      statusTitle: 'Processing',
       statusMessage: 'Please wait a moment',
       websocket: null,
       status: null,
@@ -100,7 +100,7 @@ export default {
       return this.$store.getters['darkmode/getStatus']
     },
     hasCancel () {
-      const stat = ['SBM', 'CNF', 'ESCRW_PN', 'PD_PN']
+      const stat = ['SBM', 'CNF', 'ESCRW_PN']
       return stat.includes(this.status)
     },
     isChipnet () {
@@ -139,6 +139,9 @@ export default {
       this.websocketManager.subscribeToMessages((message) => {
         if (message.status) {
           this.status = message?.status?.status?.value
+          if (this.status === 'RLS') {
+            this.txid = message?.txdata?.txid
+          }
         }
       })
     },

--- a/src/components/cash-in/payment-confirmation.vue
+++ b/src/components/cash-in/payment-confirmation.vue
@@ -87,12 +87,10 @@
         outlined
         color="blue-12"
         label="Select Image"
+        @update:model-value="onUploadAttachment"
         @rejected="onRejectedFilePick">
         <template v-slot:prepend>
           <q-icon name="image" />
-        </template>
-        <template v-slot:append>
-          <q-btn flat dense :disable="!attachment" :loading="uploading" padding="none" icon="cloud_upload" color="blue" @click="onUploadAttachment" />
         </template>
       </q-file>
     </div>

--- a/src/components/ramp/fiat/PaymentConfirmation.vue
+++ b/src/components/ramp/fiat/PaymentConfirmation.vue
@@ -75,36 +75,35 @@
                 :label="method.payment_type"
                 expand-separator >
                 <q-card class="row q-py-sm q-px-md pt-card" :class="getDarkModeClass(darkMode)">
-                  <div class="col q-pr-sm q-py-xs">
-                    <div v-for="(field, index) in method.values" :key="index">
-                      <div v-if="field.value">{{ field.field_reference.fieldname }}:</div>
-                      <div v-if="field.value" class="q-ml-sm text-weight-bold">
-                        {{ field.value }}
-                        <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(field.value)"/>
+                  <div class="row">
+                    <div class="col q-pr-sm q-py-xs">
+                      <div v-for="(field, index) in method.values" :key="index">
+                        <div v-if="field.value">{{ field.field_reference.fieldname }}:</div>
+                        <div v-if="field.value" class="q-ml-sm text-weight-bold">
+                          {{ field.value }}
+                          <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(field.value)"/>
+                        </div>
+                      </div>
+                      <div v-for="(field, index) in method.dynamic_values" :key="index">
+                          {{ field.fieldname }}
+                          <div class="q-ml-sm text-weight-bold">
+                            {{ dynamicVal(field) }}
+                            <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(dynamicVal(field))"/>
+                          </div>
                       </div>
                     </div>
-                    <div v-for="(field, index) in method.dynamic_values" :key="index">
-                        {{ field.fieldname }}
-                        <div class="q-ml-sm text-weight-bold">
-                          {{ dynamicVal(field) }}
-                          <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(dynamicVal(field))"/>
-                        </div>
+                    <div v-if="data?.type !== 'seller'">
+                      <q-checkbox v-model="method.selected" @click="selectPaymentMethod(method)" :dark="darkMode"/>
                     </div>
                   </div>
-                  <div v-if="method.attachments?.length > 0" class="col q-py-xs">
-                    <div class="row justify-end q-mr-md">
-                      <q-img
-                        :src="method.attachments[0].image?.url"
-                        style="max-height: 80px; max-width: 150px;"
-                        @click="viewPaymentAttachment(method.attachments[0].image?.url)">
-                        <div class="absolute-full text-subtitle2 flex flex-center text-bow" style="font-style: italic">
-                          {{ method.attachments?.length }} attachment(s)
-                        </div>
-                      </q-img>
-                    </div>
-                  </div>
-                  <div v-if="data?.type !== 'seller'">
-                    <q-checkbox v-model="method.selected" @click="selectPaymentMethod(method)" :dark="darkMode"/>
+                  <div v-if="method.attachments?.length > 0" class="row justify-center">
+                    <q-btn
+                      flat dense no-caps
+                      icon="image"
+                      class="row button button-text-primary q-my-none q-py-none"
+                      label="View Proof of Payment"
+                      style="font-size: small;"
+                      @click="viewPaymentAttachment(method.attachments[0].image?.url)"/>
                   </div>
                 </q-card>
               </q-expansion-item>

--- a/src/components/ramp/fiat/PaymentConfirmation.vue
+++ b/src/components/ramp/fiat/PaymentConfirmation.vue
@@ -75,35 +75,37 @@
                 :label="method.payment_type"
                 expand-separator >
                 <q-card class="row q-py-sm q-px-md pt-card" :class="getDarkModeClass(darkMode)">
-                  <div class="row">
-                    <div class="col q-pr-sm q-py-xs">
-                      <div v-for="(field, index) in method.values" :key="index">
-                        <div v-if="field.value">{{ field.field_reference.fieldname }}:</div>
-                        <div v-if="field.value" class="q-ml-sm text-weight-bold">
-                          {{ field.value }}
-                          <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(field.value)"/>
+                  <div class="col">
+                    <div class="row">
+                      <div class="col q-pr-sm q-py-xs">
+                        <div v-for="(field, index) in method.values" :key="index">
+                          <div v-if="field.value">{{ field.field_reference.fieldname }}:</div>
+                          <div v-if="field.value" class="q-ml-sm text-weight-bold">
+                            {{ field.value }}
+                            <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(field.value)"/>
+                          </div>
+                        </div>
+                        <div v-for="(field, index) in method.dynamic_values" :key="index">
+                            {{ field.fieldname }}
+                            <div class="q-ml-sm text-weight-bold">
+                              {{ dynamicVal(field) }}
+                              <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(dynamicVal(field))"/>
+                            </div>
                         </div>
                       </div>
-                      <div v-for="(field, index) in method.dynamic_values" :key="index">
-                          {{ field.fieldname }}
-                          <div class="q-ml-sm text-weight-bold">
-                            {{ dynamicVal(field) }}
-                            <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(dynamicVal(field))"/>
-                          </div>
+                      <div v-if="data?.type !== 'seller'">
+                        <q-checkbox v-model="method.selected" @click="selectPaymentMethod(method)" :dark="darkMode"/>
                       </div>
                     </div>
-                    <div v-if="data?.type !== 'seller'">
-                      <q-checkbox v-model="method.selected" @click="selectPaymentMethod(method)" :dark="darkMode"/>
+                    <div v-if="method.attachments?.length > 0" class="row">
+                      <q-btn
+                        flat dense no-caps
+                        icon="image"
+                        class="row button button-text-primary q-my-none q-py-none"
+                        label="View Proof of Payment"
+                        style="font-size: small;"
+                        @click="viewPaymentAttachment(method.attachments[0].image?.url)"/>
                     </div>
-                  </div>
-                  <div v-if="method.attachments?.length > 0" class="row justify-center">
-                    <q-btn
-                      flat dense no-caps
-                      icon="image"
-                      class="row button button-text-primary q-my-none q-py-none"
-                      label="View Proof of Payment"
-                      style="font-size: small;"
-                      @click="viewPaymentAttachment(method.attachments[0].image?.url)"/>
                   </div>
                 </q-card>
               </q-expansion-item>

--- a/src/components/ramp/fiat/StandByDisplay.vue
+++ b/src/components/ramp/fiat/StandByDisplay.vue
@@ -76,32 +76,33 @@
                     :label="method.payment_type"
                     expand-separator >
                     <q-card class="row no-wrap q-py-sm q-px-md pt-card" :class="getDarkModeClass(darkMode)">
-                      <div class="col q-pr-sm q-py-xs">
-                        <div v-for="(field, index) in method.values" :key="index">
-                          <div v-if="field.value">{{ field.field_reference.fieldname }}:</div>
-                          <div v-if="field.value" class="q-ml-sm text-weight-bold">
-                            {{ field.value }}
-                            <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(field.value)"/>
-                          </div>
-                        </div>
-                        <div v-for="(field, index) in method.dynamic_values" :key="index">
-                          {{ field.fieldname }}
-                          <div class="q-ml-sm text-weight-bold">
-                            {{ dynamicVal(field) }}
-                            <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(dynamicVal(field))"/>
-                          </div>
-                        </div>
-                      </div>
-                      <div v-if="method.attachments?.length > 0" class="col q-py-md">
-                        <div class="row justify-end q-mr-md">
-                          <q-img
-                            :src="method.attachments[0].image?.url"
-                            style="max-height: 80px; max-width: 80px;"
-                            @click="viewPaymentAttachment(method.attachments[0].image?.url)">
-                            <div class="absolute-full text-subtitle2 flex flex-center text-center" style="font-style: italic">
-                              {{ method.attachments?.length }} image(s)
+                      <div class="col">
+                        <div class="row">
+                          <div class="col q-pr-sm q-py-xs">
+                            <div v-for="(field, index) in method.values" :key="index">
+                              <div v-if="field.value">{{ field.field_reference.fieldname }}:</div>
+                              <div v-if="field.value" class="q-ml-sm text-weight-bold">
+                                {{ field.value }}
+                                <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(field.value)"/>
+                              </div>
                             </div>
-                          </q-img>
+                            <div v-for="(field, index) in method.dynamic_values" :key="index">
+                              {{ field.fieldname }}
+                              <div class="q-ml-sm text-weight-bold">
+                                {{ dynamicVal(field) }}
+                                <q-icon size="1em" name='o_content_copy' color="blue-grey-6" @click="copyToClipboard(dynamicVal(field))"/>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div v-if="method.attachments?.length > 0" class="row">
+                          <q-btn
+                            flat dense no-caps
+                            icon="image"
+                            class="row button button-text-primary q-my-none q-py-none"
+                            label="View Proof of Payment"
+                            style="font-size: small;"
+                            @click="viewPaymentAttachment(method.attachments[0].image?.url)"/>
                         </div>
                       </div>
                     </q-card>


### PR DESCRIPTION
- Proof of payment file input now uploads once user selects a file
- Removed manual proof of payment upload button
- Hide cancel button when order is already waiting for fund release
- Changed UI to view proof of payment to a `q-btn` (instead of a `q-img` ) in order process page
- Hide cash-in button if currency is not supported by P2P Exchange