### PR TITLE
fix/wallet-info-modal

### DIFF
--- a/src/components/multi-wallet/BasicInfoDialog.vue
+++ b/src/components/multi-wallet/BasicInfoDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-dialog persistent seamless ref="dialog">
+  <q-dialog persistent ref="dialog">
     <q-card class="q-pa-md pt-card text-bow" :class="getDarkModeClass(darkMode)">
       <div class="row justify-end">
         <q-btn


### PR DESCRIPTION
- removed seamless property in wallet basic info modal to prevent clicking anything outside the modal