### PR TITLE
fix/one-wallet-deletion-infinite-loading

### DIFF
--- a/src/pages/apps/wallet-info.vue
+++ b/src/pages/apps/wallet-info.vue
@@ -632,6 +632,7 @@ export default {
         if (vaultCheck.length === 0) {
           vm.$store.commit('global/clearVault')
           vm.$router.push('/accounts')
+          setTimeout(() => { location.reload() }, 500)
         } else {
           vm.switchWallet(undeletedWallets[0])
         }


### PR DESCRIPTION
- added reload upon deletion of wallet when deleting only wallet in device