### PR TITLE
Added redirect to send page when clicking transaction notifications

### DIFF
--- a/src/components/notifications/index.vue
+++ b/src/components/notifications/index.vue
@@ -74,6 +74,7 @@
                     :key="`notif-${index}`"
                     @left="(event) => onSwipe(event, index)"
                     @right="(event) => onSwipe(event, index)"
+                    @click="clickRedirect(notif)"
                     v-if="!notif.is_hidden"
                   >
                     <template v-slot:left>
@@ -223,6 +224,42 @@ export default {
           this.notifsTypes = data
           this.refreshNotifsList(null)
         })
+    },
+    clickRedirect (notif) {
+      const vm = this
+      console.log('item redirect yey')
+      vm.$refs['notifs-dialog'].hide()
+      switch (notif.notif_type) {
+        case 'TR': {
+          console.log('transaction notif yey')
+          if (notif.extra_url !== '') {
+            const query = {
+              assetId: vm.$store.getters['assets/getAssets'][0].id,
+              tokenType: 1,
+              network: 'BCH',
+              address: notif.extra_url
+            }
+            vm.$router.push({
+              name: 'transaction-send',
+              query
+            })
+          }
+          break
+        } case 'MP': {
+          console.log('marketplace notif yey')
+          break
+        } case 'AH': {
+          console.log('anyhedge notif yey')
+          break
+        } case 'RP': {
+          console.log('p2p exchange notif yey')
+          break
+        } case 'CB': {
+          console.log('cashback notif yey')
+          break
+        } default:
+          break
+      }
     },
 
     formatDate (date) {

--- a/src/components/notifications/index.vue
+++ b/src/components/notifications/index.vue
@@ -225,19 +225,25 @@ export default {
           this.refreshNotifsList(null)
         })
     },
-    clickRedirect (notif) {
+    async clickRedirect (notif) {
       const vm = this
-      console.log('item redirect yey')
       vm.$refs['notifs-dialog'].hide()
+
       switch (notif.notif_type) {
         case 'TR': {
           console.log('transaction notif yey')
-          if (notif.extra_url !== '') {
+          const url = notif.extra_url
+          if (url !== '') {
+            // automatically hide JPP payment request notifications after clicking
+            if (url.includes('bitcoincash:?')) {
+              await hideItemUpdate(notif)
+            }
+
             const query = {
               assetId: vm.$store.getters['assets/getAssets'][0].id,
               tokenType: 1,
               network: 'BCH',
-              address: notif.extra_url
+              address: url
             }
             vm.$router.push({
               name: 'transaction-send',


### PR DESCRIPTION
## Description
This PR adds a functionality in the notifications dialog which allows notifications to be clickable and redirect to respective pages depending on the notification type. In this PR, transaction notifications were given priority as to address a request to make JPP payment request notifications clickable.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## @mentions
@joemarct 
