### PR TITLE
Improvement/delivery options

### DIFF
--- a/src/components/marketplace/checkout/StorePickupDialog.vue
+++ b/src/components/marketplace/checkout/StorePickupDialog.vue
@@ -4,7 +4,7 @@
     ref="dialogRef"
     @hide="onDialogHide"
     position="bottom"
-    persistent
+    :persistent="!viewOnly"
   >
     <q-card
       class="dialog-content-base br-15 text-bow"
@@ -48,7 +48,9 @@
           </div>
         </q-banner>
         <LeafletMapDialog v-model="showMap" :locations="mapLocations" :autoCenter="true"/>
-        <div class="q-gutter-y-sm q-mt-md">
+        <div v-if="viewOnly" class="q-mt-md">
+        </div>
+        <div v-else class="q-gutter-y-sm q-mt-md">
           <q-btn
             no-caps label="Pick up from store instead"
             color="brandblue"
@@ -93,6 +95,7 @@ export default defineComponent({
   props: {
     modelValue: Boolean,
     storefront: Storefront,
+    viewOnly: Boolean,
     title: {
       type: String,
       default: 'No riders available nearby',

--- a/src/marketplace/objects.js
+++ b/src/marketplace/objects.js
@@ -148,6 +148,8 @@ export class Storefront {
   }
 
   /**
+   * @typedef {'local_delivery' | 'store_pickup' | 'shipping'} DeliveryType
+   * 
    * @param {Object} data 
    * @param {Number} data.id
    * @param {Boolean} data.active
@@ -156,6 +158,7 @@ export class Storefront {
    * @param {String} data.image_url
    * @param {String} [data.phone_number]
    * @param {{ code:String, symbol:String }} data.currency
+   * @param {DeliveryType[]} data.delivery_types
    * @param {String} data.open_status
    * @param {[String, String]} [data.next_open_hours]
    * @param {{ average_rating: String | Number, count: Number }} [data.orders_review_summary]
@@ -176,6 +179,7 @@ export class Storefront {
       code: data?.currency?.code,
       symbol: data?.currency?.symbol,
     }
+    this.deliveryTypes = data?.delivery_types
     this.openStatus = data?.open_status
     if (data?.next_open_hours?.[0] && data?.next_open_hours?.[1]) {
       this.nextOpenHours = [
@@ -201,6 +205,12 @@ export class Storefront {
     else if (this.location) this.location = undefined
 
     this.distance = data?.distance
+  }
+
+  get isStorepickupOnly() {
+    if (!Array.isArray(this.deliveryTypes)) return
+
+    return this.deliveryTypes.length === 1 && this.deliveryTypes[0] === Checkout.DeliveryTypes.STORE_PICKUP
   }
 
   get isOpen() {

--- a/src/pages/apps/gifts/create-gift.vue
+++ b/src/pages/apps/gifts/create-gift.vue
@@ -121,7 +121,7 @@
               type="submit"
               :label="$t('Generate')"
               class="flex flex-center button"
-              :disable="(createNewCampaign && !campaignName) || disableGenerateButton()"
+              :disable="(createNewCampaign && !campaignName) || disableGenerateButton() || amountBCH > spendableBch"
               @click="processRequest()"
             >
             </q-btn>
@@ -268,7 +268,7 @@ export default {
       }
     },
     disableGenerateButton () {
-      if (this.amountBCH > 0) {
+      if (this.amountBCH > 0.00001) {
         if (this.$refs.amountInput && !this.$refs.amountInput.hasError) {
           if (this.$refs.campaignInput) {
             if (this.$refs.campaignInput.hasError) {

--- a/src/pages/apps/gifts/index.vue
+++ b/src/pages/apps/gifts/index.vue
@@ -87,7 +87,7 @@
                   <div class="row">
                     <div class="q-space">{{ $t('Amount') }}</div>
                     <div class="text-caption text-grey">
-                      {{ getAssetDenomination(gift?.amount) }}
+                      {{ getAssetDenomination(denomination, gift?.amount) }}
                     </div>
                   </div>
                   <div class="row">

--- a/src/pages/apps/marketplace/index.vue
+++ b/src/pages/apps/marketplace/index.vue
@@ -95,7 +95,12 @@
                   </div>
                 </q-menu>
               </div>
-              <q-badge v-if="!storefront?.inPrelaunch && !storefront?.isOpen" color="grey">Closed</q-badge>
+              <q-badge v-if="!storefront?.inPrelaunch && !storefront?.isOpen" color="grey" class="q-mr-xs">
+                Closed
+              </q-badge>
+              <q-badge v-if="!storefront?.inPrelaunch && storefront?.isStorepickupOnly" color="info" class="q-mr-xs">
+                Store pickup
+              </q-badge>
               <div class="ellipsis-3-lines">{{ storefront.name }}</div>
               <div v-if="!storefront?.isOpen && storefront?.openingTimeText" class="text-caption bottom">
                 {{ storefront?.openingTimeText }}
@@ -302,6 +307,7 @@ async function updateLocation() {
 const customerCoordinates = computed(() => $store.getters['marketplace/customerCoordinates'])
 watch(customerCoordinates, () => fetchStorefronts())
 
+const deliveryTypes = ref([].map(String))
 const fetchingStorefronts = ref(false)
 const storefronts = ref([].map(Storefront.parse))
 const storefrontsPagination = ref({ count: 0, limit: 0, offset: 0 })
@@ -335,6 +341,7 @@ async function fetchStorefronts(opts={ limit: 0, offset: 0 }) {
   const params = {
     limit: opts?.limit || 6,
     offset: opts?.offset || undefined,
+    delivery_types: deliveryTypes.value?.join(',') || undefined,
     distance: '',
     active: true,
     annotate_is_open_at: getISOWithTimezone(new Date()),

--- a/src/pages/apps/marketplace/storefront.vue
+++ b/src/pages/apps/marketplace/storefront.vue
@@ -37,7 +37,7 @@
           </div>
         </template>
       </div>
-      <div v-if="deliveryCalculation?.fee" class="row items-center no-wrap q-px-sm">
+      <div v-if="!storefront?.isStorepickupOnly && deliveryCalculation?.fee" class="row items-center no-wrap q-px-sm">
         <div class="q-space">
           Delivery:
           {{ deliveryCalculation?.fee }} {{ deliveryCalculation?.currencySymbol }}
@@ -123,6 +123,39 @@
           </template>
         </q-input>
       </div>
+      <q-banner
+        v-if="storefront?.isStorepickupOnly === true"
+        rounded
+        inline-actions
+        class="q-my-md q-mx-sm bg-grad"
+      >
+        <template v-if="!canShowPickupDialog" v-slot:avatar>
+          <q-icon name="storefront"/>
+        </template>
+        <template v-else v-slot:action>
+          <q-btn
+            outline
+            round
+            icon="storefront"
+            padding="0.75rem"
+            size="1.25rem"
+            @click="() => showPickupDialog = true"
+          />
+          <StorePickupDialog
+            v-model="showPickupDialog"
+            view-only
+            title="Store location"
+            message=""
+            :storefront="storefront"
+            :relativeLocation="customerCoordinates"
+          />
+        </template>
+        <div class="text-h6" style="line-height:1.2">Store pickup only</div>
+        <div>This store is for store pickup only</div>
+        <div v-if="deliveryCalculation?.distance">
+          {{ round(deliveryCalculation?.distance, 1) / 1000 }} km away
+        </div>
+      </q-banner>
       <q-banner
         v-if="cashbackCampaign?.id"
         rounded
@@ -347,6 +380,7 @@ import { ref, computed, watch, onMounted, onActivated, onDeactivated, watchEffec
 import HeaderNav from 'src/components/header-nav.vue'
 import LimitOffsetPagination from 'src/components/LimitOffsetPagination.vue'
 import ReviewsListDialog from 'src/components/marketplace/reviews/ReviewsListDialog.vue'
+import StorePickupDialog from 'src/components/marketplace/checkout/StorePickupDialog.vue'
 import { debounce } from 'quasar'
 
 
@@ -469,6 +503,11 @@ function updateLivenessStatus() {
     })
 }
 
+const canShowPickupDialog = computed(() => {
+  return Number.isFinite(customerCoordinates.value?.longitude) &&
+        Number.isFinite(customerCoordinates.value?.latitude)
+})
+const showPickupDialog = ref(false)
 const customerCoordinates = computed(() => $store.getters['marketplace/customerCoordinates'])
 const deliveryCalculation = ref({
   fee: 0,

--- a/src/store/marketplace/mutations.js
+++ b/src/store/marketplace/mutations.js
@@ -1,7 +1,7 @@
 import { DEVICE_LOCATION_ID_CONST } from "./state"
 
 export function setShopListOpts(state, data) {
-  state.shopListOpts = data
+  Object.assign(state.shopListOpts, data)
 }
 
 export function setSelectedSessionLocationId(state, id=DEVICE_LOCATION_ID_CONST) {

--- a/src/store/marketplace/state.js
+++ b/src/store/marketplace/state.js
@@ -4,6 +4,7 @@ export default function () {
   return {
     shopListOpts: {
       radius: 30, // kilometers
+      deliveryType: '',
     },
     customerData: {
       id: 0,

--- a/src/store/marketplace/state.js
+++ b/src/store/marketplace/state.js
@@ -55,6 +55,7 @@ export default function () {
         image_url: '',
         name: '',
         currency: { code: '', symbol: '' },
+        delivery_types: [],
         location: {
           id: 0,
           address1: '', address2: '',


### PR DESCRIPTION
## Description
Add delivery options list in storefront data to include merchants that will only allow store pickup.

## Screenshots:
(Include screenshots for UI-related changes)
Storefronts list             |  Storefront page (store pickup only) | Storefront (default)
:-------------------------:|:-------------------------:|:-------------------------:
![localhost_9000_(Realme 8) (6)](https://github.com/user-attachments/assets/12328b48-82c0-417c-bf3f-2f4d2d2f4514)  |  ![localhost_9000_(Realme 8) (7)](https://github.com/user-attachments/assets/1f3a9352-8e96-4787-98c5-c6ee3082a07e) | ![localhost_9000_(Realme 8) (8)](https://github.com/user-attachments/assets/a7168722-d43b-4e09-a3ff-c3eee3210209)


Storefront setting from paytaca POS
![localhost_8080_(Realme 8)](https://github.com/user-attachments/assets/68711bc8-546d-4002-aa4c-243232225f41)


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested manually using local server

Display store pickup badge & banner (See screenshots)
1. Set a storefront to only store pickup, this can be done either:
  - In paytaca POS, set in `Marketplace > Storefront > Settings` page (will need [this change](https://github.com/paytaca/paytaca-pos/pull/54))
  - Change in server's django admin in `Connecta > Storefront` page if you have access to marketplace backend's admin interface
2. Refresh marketplace index page in app. `Store pickup` badge will show on shops that only support store pickup
3. Press on store with `Store pickup` badge. A banner indicating store is for pickup only is displayed and delivery details (e.g. delivery fee) is not shown (See screenshots for comparison)

Delivery type filter in marketplace index page

1. Pressing one delivery type to filter shops that support the selected delivery type
2. Press the same delivery type again to remove the filter

