### PR TITLE
fix custom keyboard covering chat input

### DIFF
--- a/src/components/ramp/fiat/dialogs/ChatDialog.vue
+++ b/src/components/ramp/fiat/dialogs/ChatDialog.vue
@@ -5,7 +5,7 @@
     full-width
   >
    <!--Title  -->
-  <q-card class="br-15 pt-card" :style="`height: ${maxHeight}px;`" :dark="darkMode" :class="getDarkModeClass(darkMode)">
+  <q-card ref="container" class="br-15 pt-card" :style="`max-height: ${maxHeight}px;`" :dark="darkMode" :class="getDarkModeClass(darkMode)">
     <div class="row items-center justify-between q-mr-lg q-pb-xs">
       <div class="q-pl-lg q-mt-md">
         <div
@@ -199,6 +199,11 @@
         dense
         v-model="message"
         :placeholder="$t('EnterMessage')"
+        @focus="() => {
+          let element = $refs.container.$el
+
+          element.scrollTop = element.scrollHeight
+        }"
         @update:modelValue="function(){
             typingMessage()
           }"


### PR DESCRIPTION
## Description
Fix instance of custom keyboard covering the chat input box

Fixes # (issue)
Scroll to bottom @focus on input box

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## @mentions
@joemarct 
