### PR TITLE
Add Platform as Header in Send Request to Create Contract Address

### DIFF
--- a/src/components/ramp/fiat/EscrowTransfer.vue
+++ b/src/components/ramp/fiat/EscrowTransfer.vue
@@ -363,6 +363,19 @@ export default {
           }
         })
     },
+    getPlatform () {
+      let platform = null
+      if (this.$q.platform.is.mobile) {
+        platform = 'android'
+      }
+      if (this.$q.platform.is.ios) {
+        platform = 'ios'
+      }
+      if (this.$q.platform.is.bex) {
+        platform = 'web'
+      }
+      return platform
+    },
     generateContractAddress (force = false) {
       return new Promise((resolve, reject) => {
         const vm = this
@@ -371,7 +384,11 @@ export default {
           arbiter_id: vm.selectedArbiter?.id,
           force: force
         }
-        backend.post('/ramp-p2p/order/contract/', body, { headers: { version: packageInfo.version }, authorize: true })
+        const headers = {
+          version: packageInfo.version,
+          platform: this.getPlatform()
+        }
+        backend.post('/ramp-p2p/order/contract/', body, { headers: headers, authorize: true })
           .then(response => {
             vm.contractAddress = response.data?.address
             vm.loading = false


### PR DESCRIPTION
## Description
This PR adds the platform as a header in the send request to the create contract address. The functionality ensures that the request includes the platform information, but the endpoint should still work even if the platform header is not present.

### Changes Made:
- Updated the request to include the platform (web/android/ios) as a header in the create contract address endpoint.
- Ensured backward compatibility, allowing the endpoint to function without the platform header.

### Acceptance Criteria
- The send request to the create contract address should include the platform header.
- The endpoint should still function correctly without the platform header.

## Screenshots (if applicable):
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes
### How Has This Been Tested?
Tested the request with and without the platform header to ensure both scenarios work correctly.
- Will the applied changes affect other areas of the code? No.
- Will the applied changes affect functionalities of other features? No.

## @mentions
@joemarct 
