### PR TITLE
fix/wallet-info-dialog-balance-mismatch

### DIFF
--- a/src/components/multi-wallet/BasicInfoDialog.vue
+++ b/src/components/multi-wallet/BasicInfoDialog.vue
@@ -83,6 +83,9 @@ export default {
     darkMode () {
       return this.$store.getters['darkmode/getStatus']
     },
+    isChipnet() {
+      return this.$store.getters['global/isChipnet']
+    },
     denomination () {
       return this.$store.getters['global/denomination']
     },
@@ -96,7 +99,10 @@ export default {
     parseAssetDenomination,
     parseFiatCurrency,
     getAssetData () {
-      return this.$store.getters['assets/getVault'][this.vaultIndex]?.asset[0]
+      const index = this.vaultIndex
+      return this.isChipnet
+        ? this.$store.getters['assets/getVault'][index].chipnet_assets[0]
+        : this.$store.getters['assets/getVault'][index].asset[0]
     },
     getAssetMarketBalance (asset) {
       if (!asset?.id) return ''


### PR DESCRIPTION
## Description
Fix incorrect balance used in wallet info dialog when chipnet is enabled

Fixes # (issue)
Bug#13 [\[1\]](https://app.asana.com/0/1208358797597635/1208405172972586), [\[2\]](https://scibizinformatics.slack.com/lists/T04RT6J7G/F07N8SDNF6V?record_id=Rec07NPUELBU7)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


## Test Notes
Manually tested
1. Check balance in multi-wallet dialog
2. Send BCH to another wallet
3. Check balance again in multi wallet dialog
