### PR TITLE
Fix/token amount parser

### DIFF
--- a/src/pages/transaction/index.vue
+++ b/src/pages/transaction/index.vue
@@ -598,7 +598,7 @@ export default {
       return asset
     },
     bchBalanceText() {
-      if (!this.balanceLoaded) return '0'
+      if (!this.balanceLoaded && this.selectedAsset?.id === this?.bchAsset?.id) return '0'
       const currentDenomination = this.selectedDenomination
       const balance = this.stablehedgeView
         ? this.stablehedgeWalletData.balance

--- a/src/utils/denomination-utils.js
+++ b/src/utils/denomination-utils.js
@@ -34,7 +34,7 @@ export function parseAssetDenomination (denomination, asset, isInput = false, su
   } else {
     const isSLP = asset.id?.startsWith('slp/')
     let newBalance = String(
-      parseFloat(convertTokenAmount(asset.balance, asset.decimals, isBCH, isSLP))
+      parseFloat(convertTokenAmount(asset.balance, asset.decimals, asset.decimals, isBCH, isSLP))
     ).substring(0, setSubStringMaxLength)
     if (asset.thousandSeparator) {
       newBalance = parseFloat(newBalance).toLocaleString('en-US', {

--- a/src/utils/denomination-utils.js
+++ b/src/utils/denomination-utils.js
@@ -1,4 +1,4 @@
-import { convertTokenAmount } from 'src/wallet/chipnet'
+import { convertTokenAmount, convertToTokenAmountWithDecimals } from 'src/wallet/chipnet'
 
 const denomDecimalPlaces = {
   BCH: { convert: 1, decimal: 8 },
@@ -34,8 +34,8 @@ export function parseAssetDenomination (denomination, asset, isInput = false, su
   } else {
     const isSLP = asset.id?.startsWith('slp/')
     let newBalance = String(
-      parseFloat(convertTokenAmount(asset.balance, asset.decimals, asset.decimals, isBCH, isSLP))
-    ).substring(0, setSubStringMaxLength)
+      parseFloat(convertToTokenAmountWithDecimals(asset.balance, asset.decimals, isBCH, isSLP))
+    )
     if (asset.thousandSeparator) {
       newBalance = parseFloat(newBalance).toLocaleString('en-US', {
         maximumFractionDigits: asset.decimal

--- a/src/utils/denomination-utils.js
+++ b/src/utils/denomination-utils.js
@@ -38,7 +38,7 @@ export function parseAssetDenomination (denomination, asset, isInput = false, su
     )
     if (asset.thousandSeparator) {
       newBalance = parseFloat(newBalance).toLocaleString('en-US', {
-        maximumFractionDigits: asset.decimal
+        maximumFractionDigits: asset.decimals,
       })
     }
     completeAsset = `${newBalance} ${asset.symbol}`


### PR DESCRIPTION
## Description
- Fix amount in transaction list not showing decimals for token transactions
- Fix bch card balance displaying '0' when fetching token balance

## Screenshots (if applicable):
![Tx record with decimals](https://github.com/user-attachments/assets/9ff52a62-49df-4917-ae32-951e7962c2f4)
![Fetching token balance](https://github.com/user-attachments/assets/2ede29af-d270-44f8-8fdd-6412eb9be943)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Click on a token in asset card list
- Check if bch balance not changing to '0' anymore
- Check txs in list with decimals actually showing decimal values
- Check txs in list with amount >1000 showing comma separated value
