### PR TITLE
Added a button to allow sellers to cancel after order is confirmed

### DIFF
--- a/src/components/ramp/fiat/EscrowTransfer.vue
+++ b/src/components/ramp/fiat/EscrowTransfer.vue
@@ -111,6 +111,16 @@
     <div v-if="!loading && !hasArbiters" class="warning-box q-mx-lg q-my-sm" :class="darkMode ? 'warning-box-dark' : 'warning-box-light'">
       There’s currently no arbiter assigned for transactions related to this ad in its currency ({{ this.order?.ad?.fiat_currency?.symbol }}). Please try again later.
     </div>
+    <div class="row q-mt-sm q-pt-xs q-mx-lg">
+      <q-btn
+        flat
+        :disable="!showDragSlide"
+        label="Cancel order"
+        class="q-space text-white br-15"
+        color="blue-6"
+        @click="$emit('cancel')"
+      />
+    </div>
     <RampDragSlide
       :key="dragSlideKey"
       :locked="!contractAddressMatch"
@@ -160,7 +170,7 @@ export default {
       minHeight: this.$q.platform.is.ios ? this.$q.screen.height - 130 : this.$q.screen.height - 100
     }
   },
-  emits: ['back', 'success', 'refresh', 'updateArbiterStatus', 'sending'],
+  emits: ['back', 'success', 'refresh', 'updateArbiterStatus', 'sending', 'cancel'],
   components: {
     RampDragSlide
   },

--- a/src/pages/apps/exchange/peer_to_peer/order.vue
+++ b/src/pages/apps/exchange/peer_to_peer/order.vue
@@ -51,6 +51,7 @@
             @back="onBack"
             @refresh="generateContract"
             @updateArbiterStatus="onUpdateArbiterStatus"
+            @cancel="cancellingOrder"
           />
           <VerifyTransaction
             v-if="state === 'tx-confirmation'"


### PR DESCRIPTION
## Description
Added a button to allow sellers to cancel after order is confirmed. This change is required to provide sellers with more flexibility in managing their orders. It solves the problem of sellers being unable to cancel orders that have been confirmed, which can lead to inconvenience and potential issues.

## Screenshots (if applicable):
![localhost_9000_(iPhone SE) (10)](https://github.com/user-attachments/assets/b0a51438-d94f-46de-b143-ea2737e8aa9e) ![localhost_9000_(iPhone SE) (9)](https://github.com/user-attachments/assets/2479041d-da37-4658-aa83-1e8dd1a2ea50)


## Type of Change
[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update

## Test Notes
### How Has This Been Tested? 
The change has been tested by manually triggering the button and verifying that the order cancellation process functions as expected. Testing included:

- Verifying that the button appears only for confirmed orders on the Escrow BCH page (seller's UI).
- Ensuring that the cancellation process completes successfully.
- Checking that the order status updates correctly.

The changes are isolated to the order cancellation feature on the Escrow BCH page and do not impact other areas of the code or functionalities.