### PR TITLE
Improvements/transaction details

### DIFF
--- a/src/components/transaction.vue
+++ b/src/components/transaction.vue
@@ -203,38 +203,66 @@
                     <span v-if="transaction.recipients.length === 1">{{ $t('Recipient') }}</span>
                     <span v-if="transaction.recipients.length > 1">{{ $t('Recipients') }}</span>
                   </q-item-label>
-                  <q-item-label v-if="transaction.asset.symbol === 'BCH'">
-                    <div
-                      v-for="(data, index) in transaction.recipients"
-                      class="row col-12 q-gutter-x-sm q-mb-xs"
-                      :key="index"
-                    >
-                      <span class="col-1">#{{ index + 1 }}</span>
-                      <span class="col-5" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
-                      <span class="col-4">
+                  <template v-if="transaction.asset.symbol === 'BCH'">
+                    <q-item-label>
+                      <div
+                        v-for="(data, index) in transaction.recipients.slice(0, 10)"
+                        class="row col-12 q-gutter-x-sm q-mb-xs"
+                        :key="index"
+                      >
+                        <span class="col-1">#{{ index + 1 }}</span>
+                        <span class="col-5" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                        <span class="col-4">
+                          {{
+                            `${parseAssetDenomination(
+                                denomination === $t('DEEM') || denomination === 'BCH' ? denominationTabSelected : denomination,
+                                {
+                                  ...transaction.asset,
+                                  balance: data[1] / (10 ** 8),
+                                  thousandSeparator: true
+                                }
+                              )}`
+                          }}
+                        </span>
+                      </div>
+                      <span
+                        v-if="transaction.recipients.length > 10"
+                        class="row col-12 justify-center q-mt-sm"
+                      >
                         {{
-                          `${parseAssetDenomination(
-                              denomination === $t('DEEM') || denomination === 'BCH' ? denominationTabSelected : denomination,
-                              {
-                                ...transaction.asset,
-                                balance: data[1] / (10 ** 8),
-                                thousandSeparator: true
-                              }
-                            )}`
+                          $t(
+                            "AndMoreAddresses",
+                            { addressCount: transaction.recipients.length - 10 },
+                            `and ${transaction.recipients.length - 10} more addresses`
+                          )
                         }}
                       </span>
-                    </div>
-                  </q-item-label>
-                  <q-item-label v-else>
-                    <div
-                      v-for="(data, index) in transaction.recipients"
-                      class="row col-12 q-gutter-x-sm q-mb-xs"
-                      :key="index"
-                    >
-                      <span class="col-1">#{{ index + 1 }}</span>
-                      <span class="col-10" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
-                    </div>
-                  </q-item-label>
+                    </q-item-label>
+                  </template>
+                  <template v-else>
+                    <q-item-label>
+                      <div
+                        v-for="(data, index) in transaction.recipients.slice(0, 10)"
+                        class="row col-12 q-gutter-x-sm q-mb-xs"
+                        :key="index"
+                      >
+                        <span class="col-1">#{{ index + 1 }}</span>
+                        <span class="col-10" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                      </div>
+                      <span
+                        v-if="transaction.recipients.length > 10"
+                        class="row col-12 justify-center q-mt-sm"
+                      >
+                        {{
+                          $t(
+                            "AndMoreAddresses",
+                            { addressCount: transaction.recipients.length - 10 },
+                            `and ${transaction.recipients.length - 10} more addresses`
+                          )
+                        }}
+                      </span>
+                    </q-item-label>
+                  </template>
                 </q-item-section>
               </q-item>
             </template>

--- a/src/components/transaction.vue
+++ b/src/components/transaction.vue
@@ -203,7 +203,38 @@
                     <span v-if="transaction.recipients.length === 1">{{ $t('Recipient') }}</span>
                     <span v-if="transaction.recipients.length > 1">{{ $t('Recipients') }}</span>
                   </q-item-label>
-                  <q-item-label>{{ concatenate(transaction.recipients) }}</q-item-label>
+                  <q-item-label v-if="transaction.asset.symbol === 'BCH'">
+                    <div
+                      v-for="(data, index) in transaction.recipients"
+                      class="row col-12 q-gutter-x-sm q-mb-xs"
+                      :key="index"
+                    >
+                      <span class="col-1">#{{ index + 1 }}</span>
+                      <span class="col-5" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                      <span class="col-4">
+                        {{
+                          `${parseAssetDenomination(
+                              denomination === $t('DEEM') || denomination === 'BCH' ? denominationTabSelected : denomination,
+                              {
+                                ...transaction.asset,
+                                balance: data[1] / (10 ** 8),
+                                thousandSeparator: true
+                              }
+                            )}`
+                        }}
+                      </span>
+                    </div>
+                  </q-item-label>
+                  <q-item-label v-else>
+                    <div
+                      v-for="(data, index) in transaction.recipients"
+                      class="row col-12 q-gutter-x-sm q-mb-xs"
+                      :key="index"
+                    >
+                      <span class="col-1">#{{ index + 1 }}</span>
+                      <span class="col-10" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                    </div>
+                  </q-item-label>
                 </q-item-section>
               </q-item>
             </template>

--- a/src/components/transactions/TransactionListItem.vue
+++ b/src/components/transactions/TransactionListItem.vue
@@ -177,7 +177,7 @@ const badges = computed(() => {
   if (!Array.isArray(props.transaction?.attributes)) return []
   return props.transaction?.attributes.map(parseAttributeToBadge)
     .filter(badge => badge?.custom)
-    .filter(badge => isStablehedgeTx.value && badge.key !== 'stablehedge_transaction')
+    .filter(badge => isStablehedgeTx.value || badge.key !== 'stablehedge_transaction')
 })
 
 const stablehedgeTxData = computed(() => extractStablehedgeTxData(props.transaction))


### PR DESCRIPTION
## Description
This PR will introduce an improvement in transaction details. For all ongoing BCH transactions, the recipients list is broken down to show all recipients and amount sent to each respective address. The same improvement is also applied to all ongoing token transactions, albeit the respective amount is not shown.


## Screenshots (if applicable):
- recipient breakdown for BCH transaction
<img width="176" alt="tdbch" src="https://github.com/user-attachments/assets/261022c2-e43f-4257-a391-f394a81766f7" />

- recipient breakdown for token transactions
<img width="174" alt="tdtoken" src="https://github.com/user-attachments/assets/a5733af2-a001-4feb-b44f-986d3ed01305" />


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Feature improvement


## Test Notes
Tested locally on desktop and mobile mode, using different denominations (BCH, mBCH, Satoshis, DEEM) and different tokens.
