### PR TITLE
Added overflow wrap to avoid overflow when NFT name is too long

### DIFF
--- a/src/components/collectibles/CashTokenNFTDialog.vue
+++ b/src/components/collectibles/CashTokenNFTDialog.vue
@@ -285,5 +285,6 @@ onMounted(() => {
     z-index: 1;
     max-width: 100%;
     background: inherit;
+    overflow-wrap: anywhere;
   }
 </style>


### PR DESCRIPTION
## Description
This PR will fix the issue stated in [Bug ID 67](https://scibizinformatics.slack.com/lists/T04RT6J7G/F07N8SDNF6V?record_id=Rec0872EXN4J2), where the NFT dialog overflows when the NFT name is too long, prompting the user to scroll sideways to close said dialog.


## Screenshots (if applicable):
- overflow example for a long NFT name
<img width="173" alt="nft" src="https://github.com/user-attachments/assets/0317773e-22dd-4cdb-85a7-76b658aae509" />



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
