### PR TITLE
Fix/bug id 25

### DIFF
--- a/src/components/authOption/biometric-warning-attempt.vue
+++ b/src/components/authOption/biometric-warning-attempt.vue
@@ -1,20 +1,29 @@
 <template>
-    <div>
-      <q-dialog
-      v-model="dialog"
-      persistent
-      seamless
-      >
-        <q-card>
-            <q-card-section>
-                <p class="q-my-none pp-text">{{ $t('BiometricMaxAttemptsMsg') }}</p>
-            </q-card-section>
-        </q-card>
-      </q-dialog>
-    </div>
+  <q-dialog
+    v-model="dialog"
+    persistent
+    seamless
+    class="no-click-outside"
+  >
+    <q-card class="br-15 pt-card text-bow" :class="getDarkModeClass(darkMode)">
+      <div class="row no-wrap items-center justify-end">
+        <q-btn
+          flat
+          padding="sm"
+          icon="close"
+          class="close-button"
+          v-close-popup
+        />
+      </div>
+      <q-card-section>
+        <p class="">{{ $t('BiometricMaxAttemptsMsg') }}</p>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
 </template>
 
 <script>
+import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
 
 export default {
   data () {
@@ -31,14 +40,19 @@ export default {
       }
     }
   },
+  computed: {
+    darkMode () {
+      return this.$store.getters['darkmode/getStatus']
+    }
+  },
   methods: {
+    getDarkModeClass,
     startTimer () {
       let counter = 0
       const timer = setInterval(() => {
         counter++
         if (counter === 28) {
           clearInterval(timer)
-          this.$emit('closeBiometricWarningAttempts')
           this.dialog = false
         }
       }, 1000)
@@ -46,9 +60,3 @@ export default {
   }
 }
 </script>
-
-<style>
-.pp-text {
-  color: #000 !important;
-}
-</style>

--- a/src/components/transaction.vue
+++ b/src/components/transaction.vue
@@ -203,38 +203,66 @@
                     <span v-if="transaction.recipients.length === 1">{{ $t('Recipient') }}</span>
                     <span v-if="transaction.recipients.length > 1">{{ $t('Recipients') }}</span>
                   </q-item-label>
-                  <q-item-label v-if="transaction.asset.symbol === 'BCH'">
-                    <div
-                      v-for="(data, index) in transaction.recipients"
-                      class="row col-12 q-gutter-x-sm q-mb-xs"
-                      :key="index"
-                    >
-                      <span class="col-1">#{{ index + 1 }}</span>
-                      <span class="col-5" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
-                      <span class="col-4">
+                  <template v-if="transaction.asset.symbol === 'BCH'">
+                    <q-item-label>
+                      <div
+                        v-for="(data, index) in transaction.recipients.slice(0, 10)"
+                        class="row col-12 q-gutter-x-sm q-mb-xs"
+                        :key="index"
+                      >
+                        <span class="col-1">#{{ index + 1 }}</span>
+                        <span class="col-5" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                        <span class="col-4">
+                          {{
+                            `${parseAssetDenomination(
+                                denomination === $t('DEEM') || denomination === 'BCH' ? denominationTabSelected : denomination,
+                                {
+                                  ...transaction.asset,
+                                  balance: data[1] / (10 ** 8),
+                                  thousandSeparator: true
+                                }
+                              )}`
+                          }}
+                        </span>
+                      </div>
+                      <span
+                        v-if="transaction.recipients.length > 10"
+                        class="row col-12 justify-center q-mt-sm"
+                      >
                         {{
-                          `${parseAssetDenomination(
-                              denomination === $t('DEEM') || denomination === 'BCH' ? denominationTabSelected : denomination,
-                              {
-                                ...transaction.asset,
-                                balance: data[1] / (10 ** 8),
-                                thousandSeparator: true
-                              }
-                            )}`
+                          $t(
+                            "AndMoreAddresses",
+                            { addressCount: transaction.recipients.length - 10 },
+                            `and ${transaction.recipients.length - 10} more addresses`
+                          )
                         }}
                       </span>
-                    </div>
-                  </q-item-label>
-                  <q-item-label v-else>
-                    <div
-                      v-for="(data, index) in transaction.recipients"
-                      class="row col-12 q-gutter-x-sm q-mb-xs"
-                      :key="index"
-                    >
-                      <span class="col-1">#{{ index + 1 }}</span>
-                      <span class="col-10" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
-                    </div>
-                  </q-item-label>
+                    </q-item-label>
+                  </template>
+                  <template v-else>
+                    <q-item-label>
+                      <div
+                        v-for="(data, index) in transaction.recipients.slice(0, 10)"
+                        class="row col-12 q-gutter-x-sm q-mb-xs"
+                        :key="index"
+                      >
+                        <span class="col-1">#{{ index + 1 }}</span>
+                        <span class="col-10" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                      </div>
+                      <span
+                        v-if="transaction.recipients.length > 10"
+                        class="row col-12 justify-center q-mt-sm"
+                      >
+                        {{
+                          $t(
+                            "AndMoreAddresses",
+                            { addressCount: transaction.recipients.length - 10 },
+                            `and ${transaction.recipients.length - 10} more addresses`
+                          )
+                        }}
+                      </span>
+                    </q-item-label>
+                  </template>
                 </q-item-section>
               </q-item>
             </template>

--- a/src/components/transaction.vue
+++ b/src/components/transaction.vue
@@ -203,7 +203,38 @@
                     <span v-if="transaction.recipients.length === 1">{{ $t('Recipient') }}</span>
                     <span v-if="transaction.recipients.length > 1">{{ $t('Recipients') }}</span>
                   </q-item-label>
-                  <q-item-label>{{ concatenate(transaction.recipients) }}</q-item-label>
+                  <q-item-label v-if="transaction.asset.symbol === 'BCH'">
+                    <div
+                      v-for="(data, index) in transaction.recipients"
+                      class="row col-12 q-gutter-x-sm q-mb-xs"
+                      :key="index"
+                    >
+                      <span class="col-1">#{{ index + 1 }}</span>
+                      <span class="col-5" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                      <span class="col-4">
+                        {{
+                          `${parseAssetDenomination(
+                              denomination === $t('DEEM') || denomination === 'BCH' ? denominationTabSelected : denomination,
+                              {
+                                ...transaction.asset,
+                                balance: data[1] / (10 ** 8),
+                                thousandSeparator: true
+                              }
+                            )}`
+                        }}
+                      </span>
+                    </div>
+                  </q-item-label>
+                  <q-item-label v-else>
+                    <div
+                      v-for="(data, index) in transaction.recipients"
+                      class="row col-12 q-gutter-x-sm q-mb-xs"
+                      :key="index"
+                    >
+                      <span class="col-1">#{{ index + 1 }}</span>
+                      <span class="col-10" style="overflow-wrap: anywhere;">{{ data[0] }}</span>
+                    </div>
+                  </q-item-label>
                 </q-item-section>
               </q-item>
             </template>

--- a/src/components/transactions/TransactionListItem.vue
+++ b/src/components/transactions/TransactionListItem.vue
@@ -177,7 +177,7 @@ const badges = computed(() => {
   if (!Array.isArray(props.transaction?.attributes)) return []
   return props.transaction?.attributes.map(parseAttributeToBadge)
     .filter(badge => badge?.custom)
-    .filter(badge => isStablehedgeTx.value && badge.key !== 'stablehedge_transaction')
+    .filter(badge => isStablehedgeTx.value || badge.key !== 'stablehedge_transaction')
 })
 
 const stablehedgeTxData = computed(() => extractStablehedgeTxData(props.transaction))

--- a/src/i18n/__texts/phrases.js
+++ b/src/i18n/__texts/phrases.js
@@ -1181,7 +1181,8 @@ const phrases = {
       TransactionDetails: 'Transaction Details',
       TotalAmountSent: 'Total amount sent',
       TimeSent: 'Time sent',
-      TransactionBreakdown: 'Transaction Breakdown'
+      TransactionBreakdown: 'Transaction Breakdown',
+      AuthenticationFailed: 'Authentication failed'
     }
   ],
   dynamic: [

--- a/src/i18n/af/index.js
+++ b/src/i18n/af/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Audiotrack IDS",
   AuthSignError: "Verifikasie -uitdagingsfout",
   AuthenticationCancelled: "Verifikasie gekanselleer",
+  AuthenticationFailed: "Verifikasie het misluk",
   AutoFillFieldFromPinLocation: "Auto Fill Field vanaf die Pin -ligging?",
   AutoGenerateAddress: "Auto genereer adres",
   AutoGenerateAddressToolTip: "'N Nuwe adres sal gegenereer word na ontvangs van bates",

--- a/src/i18n/ar/index.js
+++ b/src/i18n/ar/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "IDS Audiotrack",
   AuthSignError: "خطأ في توقيع تحدي المصادقة",
   AuthenticationCancelled: "تم إلغاء المصادقة",
+  AuthenticationFailed: "فشلت المصادقة",
   AutoFillFieldFromPinLocation: "حقل تعبئة السيارات من موقع الدبوس؟",
   AutoGenerateAddress: "تلقائي إنشاء العنوان",
   AutoGenerateAddressToolTip: "سيتم إنشاء عنوان جديد بعد تلقي الأصول",

--- a/src/i18n/de/index.js
+++ b/src/i18n/de/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Audiotrack -IDs",
   AuthSignError: "Authentifizierungs -Herausforderung Signierfehler",
   AuthenticationCancelled: "Authentifizierung abgesagt",
+  AuthenticationFailed: "Authentifizierung fehlgeschlagen",
   AutoFillFieldFromPinLocation: "Automatische Füllung Feld vom PIN -Standort?",
   AutoGenerateAddress: "Automatische Adresse generieren",
   AutoGenerateAddressToolTip: "Eine neue Adresse wird nach Erhalt von Vermögenswerten generiert",

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "AudioTrack IDs",
   AuthSignError: "Authentication challenge signing error",
   AuthenticationCancelled: "Authentication cancelled",
+  AuthenticationFailed: "Authentication failed",
   AutoFillFieldFromPinLocation: "Auto fill field from pin location?",
   AutoGenerateAddress: "Auto generate address",
   AutoGenerateAddressToolTip: "A new address will be generated after receiving assets",

--- a/src/i18n/es-ar/index.js
+++ b/src/i18n/es-ar/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "IDS de audiotrack",
   AuthSignError: "Error de firma en desafío de autenticación",
   AuthenticationCancelled: "Autenticación cancelada",
+  AuthenticationFailed: "La autenticación falló",
   AutoFillFieldFromPinLocation: "Campo de relleno automático desde la ubicación del pin?",
   AutoGenerateAddress: "Generar dirección automáticamente",
   AutoGenerateAddressToolTip: "Se generará una nueva dirección después de recibir activos",

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "IDS de audiotrack",
   AuthSignError: "Error de firma en desafío de autenticación",
   AuthenticationCancelled: "Autenticación cancelada",
+  AuthenticationFailed: "La autenticación falló",
   AutoFillFieldFromPinLocation: "Campo de relleno automático desde la ubicación del pin?",
   AutoGenerateAddress: "Generar dirección automáticamente",
   AutoGenerateAddressToolTip: "Se generará una nueva dirección después de recibir activos",

--- a/src/i18n/fr/index.js
+++ b/src/i18n/fr/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "ID audioTrack",
   AuthSignError: "Erreur de signature du défi d'authentification",
   AuthenticationCancelled: "Authentification annulée",
+  AuthenticationFailed: "L'authentification a échoué",
   AutoFillFieldFromPinLocation: "Champ de remplissage automatique à partir de l'emplacement des broches?",
   AutoGenerateAddress: "Adresse automatique de génération",
   AutoGenerateAddressToolTip: "Une nouvelle adresse sera générée après avoir reçu des actifs",

--- a/src/i18n/ha/index.js
+++ b/src/i18n/ha/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "ID na Audiotrack",
   AuthSignError: "Kuskuren Ingantaccen Alamar Alkalami",
   AuthenticationCancelled: "Ingantaccen magani",
+  AuthenticationFailed: "Tabbatarwa ta kasa",
   AutoFillFieldFromPinLocation: "Mika ta atomatik daga PIN wuri?",
   AutoGenerateAddress: "Adireshin Auto",
   AutoGenerateAddressToolTip: "Ana samun sabon adireshin bayan karbar kadarori",

--- a/src/i18n/id/index.js
+++ b/src/i18n/id/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "ID AUDIOTRACK",
   AuthSignError: "Kesalahan Penandatanganan Tantangan Otentikasi",
   AuthenticationCancelled: "Otentikasi dibatalkan",
+  AuthenticationFailed: "Otentikasi gagal",
   AutoFillFieldFromPinLocation: "Lapangan Isi Otomatis dari Lokasi Pin?",
   AutoGenerateAddress: "Alamat menghasilkan otomatis",
   AutoGenerateAddressToolTip: "Alamat baru akan dihasilkan setelah menerima aset",

--- a/src/i18n/it/index.js
+++ b/src/i18n/it/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "ID audiotrack",
   AuthSignError: "Errore di firma della sfida di autenticazione",
   AuthenticationCancelled: "Autenticazione annullata",
+  AuthenticationFailed: "Autenticazione non riuscita",
   AutoFillFieldFromPinLocation: "Campo di riempimento automatico dalla posizione del pin?",
   AutoGenerateAddress: "Auto Genera Indirizzo",
   AutoGenerateAddressToolTip: "Verrà generato un nuovo indirizzo dopo aver ricevuto attività",

--- a/src/i18n/ja/index.js
+++ b/src/i18n/ja/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "audiotrack ID",
   AuthSignError: "認証チャレンジ署名エラー",
   AuthenticationCancelled: "認証がキャンセルされました",
+  AuthenticationFailed: "認証に失敗しました",
   AutoFillFieldFromPinLocation: "ピンの場所からの自動充填フィールド？",
   AutoGenerateAddress: "自動生成アドレス",
   AutoGenerateAddressToolTip: "資産を受け取った後、新しいアドレスが生成されます",

--- a/src/i18n/ko/index.js
+++ b/src/i18n/ko/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Audiotrack ID",
   AuthSignError: "인증 도전 서명 오류",
   AuthenticationCancelled: "인증이 취소되었습니다",
+  AuthenticationFailed: "인증이 실패했습니다",
   AutoFillFieldFromPinLocation: "핀 위치에서 자동 채우기 필드?",
   AutoGenerateAddress: "자동 생성 주소",
   AutoGenerateAddressToolTip: "자산을받은 후에 새로운 주소가 생성됩니다",

--- a/src/i18n/nl/index.js
+++ b/src/i18n/nl/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Audiotrack ID's",
   AuthSignError: "Authenticatie -uitdaging ondertekeningfout",
   AuthenticationCancelled: "Authenticatie geannuleerd",
+  AuthenticationFailed: "Authenticatie is mislukt",
   AutoFillFieldFromPinLocation: "Auto vulveld vanaf de pinlocatie?",
   AutoGenerateAddress: "Auto genereer adres",
   AutoGenerateAddressToolTip: "Een nieuw adres wordt gegenereerd na het ontvangen van activa",

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "IDs de fúria",
   AuthSignError: "Desafio de autenticação Erro de assinatura",
   AuthenticationCancelled: "Autenticação cancelada",
+  AuthenticationFailed: "Autenticação falhou",
   AutoFillFieldFromPinLocation: "Campo de preenchimento automático da localização do pino?",
   AutoGenerateAddress: "Endereço gerado automático",
   AutoGenerateAddressToolTip: "Um novo endereço será gerado após receber ativos",

--- a/src/i18n/pt/index.js
+++ b/src/i18n/pt/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "IDs de fúria",
   AuthSignError: "Desafio de autenticação Erro de assinatura",
   AuthenticationCancelled: "Autenticação cancelada",
+  AuthenticationFailed: "Autenticação falhou",
   AutoFillFieldFromPinLocation: "Campo de preenchimento automático da localização do pino?",
   AutoGenerateAddress: "Endereço gerado automático",
   AutoGenerateAddressToolTip: "Um novo endereço será gerado após receber ativos",

--- a/src/i18n/ru/index.js
+++ b/src/i18n/ru/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Audiotrack Ids",
   AuthSignError: "Ошибка подписания подлинности аутентификации",
   AuthenticationCancelled: "Аутентификация отменена",
+  AuthenticationFailed: "Аутентификация не удалась",
   AutoFillFieldFromPinLocation: "Поле заполнения автоматической заполнения из местоположения PIN?",
   AutoGenerateAddress: "Автоматическое генерирование адреса",
   AutoGenerateAddressToolTip: "После получения активов будет генерироваться новый адрес",

--- a/src/i18n/tl/index.js
+++ b/src/i18n/tl/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Audiotrack IDS",
   AuthSignError: "Authentication Hamon sa Pag -sign Error",
   AuthenticationCancelled: "Kinansela ang pagpapatunay",
+  AuthenticationFailed: "Nabigo ang pagpapatunay",
   AutoFillFieldFromPinLocation: "Auto Punan ang patlang mula sa lokasyon ng PIN?",
   AutoGenerateAddress: "Auto bumuo ng address",
   AutoGenerateAddressToolTip: "Ang isang bagong address ay bubuo pagkatapos matanggap ang mga ari -arian",

--- a/src/i18n/zh-cn/index.js
+++ b/src/i18n/zh-cn/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Idiotrack ID",
   AuthSignError: "身份验证挑战签名错误",
   AuthenticationCancelled: "认证取消",
+  AuthenticationFailed: "身份验证失败",
   AutoFillFieldFromPinLocation: "PIN位置自动填充字段？",
   AutoGenerateAddress: "自动生成地址",
   AutoGenerateAddressToolTip: "收到资产后将生成一个新的地址",

--- a/src/i18n/zh-tw/index.js
+++ b/src/i18n/zh-tw/index.js
@@ -112,6 +112,7 @@ export default {
   AudioTrackIDs: "Idiotrack ID",
   AuthSignError: "身份驗證挑戰簽名錯誤",
   AuthenticationCancelled: "認證取消",
+  AuthenticationFailed: "身份驗證失敗",
   AutoFillFieldFromPinLocation: "PIN位置自動填充字段？",
   AutoGenerateAddress: "自動生成地址",
   AutoGenerateAddressToolTip: "收到資產後將生成一個新的地址",

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -255,7 +255,7 @@ export default {
           this.warningAttemptsStatus = 'dismiss'
           if (error.message.includes(this.$t('MaxAttempts'))) {
             this.warningAttemptsStatus = 'show'
-          } else if (error.message.includes('Authentication failed')) {
+          } else if (error.message.includes(this.$t('AuthenticationFailed'))) {
             this.verifyBiometric()
           } else this.proceedToBackup = false
         })

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -31,7 +31,7 @@
     </div>
 
     <pinDialog v-model:pin-dialog-action="pinDialogAction" v-on:nextAction="toggleMnemonicDisplay" />
-    <biometricWarningAttempts :warning-attempts="warningAttemptsStatus" v-on:closeBiometricWarningAttempts="setwarningAttemptsStatus" />
+    <biometricWarningAttempts :warning-attempts="warningAttemptsStatus" />
     <footer-menu />
   </div>
 </template>
@@ -259,9 +259,6 @@ export default {
             this.verifyBiometric()
           } else this.proceedToBackup = false
         })
-    },
-    setwarningAttemptsStatus () {
-      this.verifyBiometric()
     },
     toggleMnemonicDisplay (action) {
       const vm = this

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -249,17 +249,15 @@ export default {
           setTimeout(() => {
             this.toggleMnemonicDisplay('proceed')
           }, 1000)
-        },
-        (error) => {
+        })
+        .catch((error) => {
           // Failed to authenticate
           this.warningAttemptsStatus = 'dismiss'
-          if (error.message.includes(this.$t('Cancel')) || error.message.includes(this.$t('AuthenticationCancelled')) || error.message.includes(this.$t('FingerprintOperationCancelled'))) {
-            this.proceedToBackup = false
-          } else if (error.message.includes(this.$t('MaxAttempts'))) {
+          if (error.message.includes(this.$t('MaxAttempts'))) {
             this.warningAttemptsStatus = 'show'
-          } else {
+          } else if (error.message.includes('Authentication failed')) {
             this.verifyBiometric()
-          }
+          } else this.proceedToBackup = false
         })
     },
     setwarningAttemptsStatus () {


### PR DESCRIPTION
## Description
This PR will introduce a bug fix to the issue reported in [Bug ID 25](https://scibizinformatics.slack.com/lists/T04RT6J7G/F07N8SDNF6V?record_id=Rec07RQ4U6U7J), where cancelling the fingerprint verification causes it to open again. The triggers are different for Android and iOS.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
The fix was tested in an Android device. Testing in iOS has not been done yet.
There are 2 actions where the fingerprint verification can be cancelled:
1. clicking the Cancel button
2. clicking outside the verification modal

Acceptance criteria should be:
1. Performing the 2 cancel actions should not prompt the fingerprint verification modal back.
2. After failing the authentication (used wrong finger to authenticate), the modal should pop back. Once the maximum number of attempts have reached, a warning status should show stating that the user should try again after 30 seconds.