### PR TITLE
Fix/marketplace ios padding

### DIFF
--- a/src/layouts/MarketplaceLayout.vue
+++ b/src/layouts/MarketplaceLayout.vue
@@ -6,7 +6,6 @@
         <q-spinner size="1.5em" class="q-ml-sm"/>
       </div>
     </q-dialog>
-    <div v-if="$q.platform.is.ios" style="padding-top:25px;"></div>
     <router-view v-slot="{ Component }">
       <keep-alive>
         <component :is="Component" v-bind="{ cartDialog: { value: showCartsDialog, toggle: toggleShowCartsDialog, cart: activeStorefrontCart } }"/>

--- a/src/pages/apps/marketplace/index.vue
+++ b/src/pages/apps/marketplace/index.vue
@@ -15,7 +15,10 @@
       <SessionLocationWidget ref="sessionLocationWidget" />
     </div>
 
-    <div class="q-px-md q-pt-xs q-pb-md sticky-below-header">
+    <div
+      class="q-px-md q-pt-xs q-pb-md sticky-below-header"
+      :class="$q.platform.is.ios ? 'sticky-below-header--ios' : ''"
+    >
       <MarketplaceSearch :customer-coordinates="customerCoordinates"/>
     </div>
 
@@ -466,5 +469,8 @@ table.orders-table td {
   position: sticky;
   top: 70px;
   z-index: 10 !important;
+}
+.sticky-below-header.sticky-below-header--ios {
+  top: 110px;
 }
 </style>


### PR DESCRIPTION
## Description
Adjust top padding in marketplace on ios devices

## Screenshots (if applicable):
![localhost_9000_(iPhone 14 Pro Max)](https://github.com/user-attachments/assets/f6a91fb8-261a-44a5-ac07-e90a7bf8f1da)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Open marketplace app on ios device
- Test scrolling down in main page if sticky search bar is visible

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
