### PR TITLE
Improvements/push notification settings

### DIFF
--- a/src/components/settings/PushNotifsSettings.vue
+++ b/src/components/settings/PushNotifsSettings.vue
@@ -223,7 +223,7 @@ export default {
 
     if (currentCity) {
       const choices = this.parseCities()
-      const city = choices.filter(a => a.id === currentCity)
+      const city = choices.filter(a => a.value === currentCity)
       vm.eventsAndPromosSubList[1].value = city[0]
     }
 
@@ -289,7 +289,6 @@ export default {
     },
     openEnterCountryCityDialog (enterType) {
       const vm = this
-
       const enterTypeText = enterType === 0 ? 'Country' : 'City'
 
       let choices = []

--- a/src/components/settings/PushNotifsSettings.vue
+++ b/src/components/settings/PushNotifsSettings.vue
@@ -194,11 +194,6 @@ export default {
             vm.eventsAndPromosSubList[1].isEnabled = configs.is_by_city_enabled
             vm.eventsAndPromosSubList[0].value = configs.country
             vm.eventsAndPromosSubList[1].value = configs.city
-
-            const countryLabel = configs.country ? this.$t('UpdateCountry') : this.$t('EnterCountry')
-            const cityLabel = configs.city ? this.$t('UpdateCity') : this.$t('EnterCity')
-            vm.eventsAndPromosSubList[0].inputLabel = countryLabel
-            vm.eventsAndPromosSubList[1].inputLabel = cityLabel
           } else await vm.handleNotifTypesSubscription(null)
         })
     }
@@ -207,6 +202,8 @@ export default {
     // set country and city value
     const currentCountry = vm.eventsAndPromosSubList[0].value
     const currentCity = vm.eventsAndPromosSubList[1].value
+    let countryLabel = this.$t('EnterCountry')
+    let cityLabel = this.$t('EnterCity')
 
     if (currentCountry) {
       const country = vm.countryCityData
@@ -219,13 +216,18 @@ export default {
           }
         })
       vm.eventsAndPromosSubList[0].value = country[0]
+      countryLabel = country[0].label
     }
 
     if (currentCity) {
       const choices = this.parseCities()
       const city = choices.filter(a => a.value === currentCity)
       vm.eventsAndPromosSubList[1].value = city[0]
+      cityLabel = city[0].label
     }
+
+    vm.eventsAndPromosSubList[0].inputLabel = countryLabel
+    vm.eventsAndPromosSubList[1].inputLabel = cityLabel
 
     this.isEnablePushNotifsLoading = false
   },
@@ -327,8 +329,13 @@ export default {
         }
       }).onOk(response => {
         vm.eventsAndPromosSubList[enterType].value = response
-        const inputLabel = this.$t(`${response ? 'Update' : 'Enter'}${enterTypeText}`)
+        const inputLabel = response ? response.label : this.$t(`Enter${enterTypeText}`)
         vm.eventsAndPromosSubList[enterType].inputLabel = inputLabel
+
+        if (enterType === 0) {
+          vm.eventsAndPromosSubList[1].value = null
+          vm.eventsAndPromosSubList[1].inputLabel = this.$t('EnterCity')
+        }
       })
     },
 

--- a/src/utils/engagementhub-utils.js
+++ b/src/utils/engagementhub-utils.js
@@ -189,8 +189,10 @@ export async function updateDeviceNotifType (deviceNotifTypesId, type, deviceId)
         data.is_by_country_enabled = type.value
       } else if (type.db_col === 'is_by_city_enabled') {
         data.is_by_city_enabled = type.value
-      } else if (type.db_col === 'country') data.country = type.value
-      else if (type.db_col === 'city') data.city = type.value
+      } else if (type.db_col === 'country') {
+        data.country = type.value
+        data.city = null
+      } else if (type.db_col === 'city') data.city = type.value
 
       await NOTIFS_URL.patch(
         `devicenotiftype/${respId}/`,


### PR DESCRIPTION
## Description
This PR will introduce a fix for the value in the Enter/Update City dialog appearing as `[object Object]` when updating, and an improvement to the country and city display; instead of Update Country/City, the current values will be displayed. An adjustment to the update logic is also present, wherein updating the Country clears the values of City (both in UI and in backend).

## Screenshots (if applicable)
- currently selected values being displayed
![image](https://github.com/user-attachments/assets/6cb0b3fe-419c-466e-98ae-c4340dbd23e5)



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Existing feature improvement


## Test Notes
The PR was tested on an Android mobile device since the push notification settings will only appear on mobile devices.
