### PR TITLE
Fix/nft image not showing

### DIFF
--- a/src/components/collectibles/CashTokensNFTGroup.vue
+++ b/src/components/collectibles/CashTokensNFTGroup.vue
@@ -12,7 +12,7 @@
         @click.stop="() => $emit('openNft', nft)"
       >
         <q-img
-          :src="getImageUrl(nft)"
+          :src="imageUrl(nft)"
           fit="fill"
           @error="() => onNftImageError(nft)"
         >
@@ -93,6 +93,22 @@ const props = defineProps({
   category: String,
   darkMode: Boolean,
 })
+
+const imageUrl = computed(() => {
+  return (nft) => {
+    const imgUrl = nft?.parsedMetadata?.imageUrl
+    if (imgUrl) {
+      if (imgUrl.startsWith('https://ipfs.paytaca.com/ipfs')) {
+        return imgUrl + '?pinataGatewayToken=' + process.env.PINATA_GATEWAY_TOKEN
+      } else {
+        return imgUrl
+      }
+    } else {
+      return generateFallbackImage(nft)
+    }
+  }
+})
+
 watch(() => [props.category, props.ungrouped, props.wallet], () => fetchNfts())
 onMounted(() => fetchNfts())
 onUpdated(() => {
@@ -162,18 +178,18 @@ function generateFallbackImage(nft=CashNonFungibleToken.parse()) {
   return $store.getters['global/getDefaultAssetLogo']?.(`${nft?.category}|${nft?.commitment}`)
 }
 
-function getImageUrl (nft) {
-  const imgUrl = nft?.parsedMetadata?.imageUrl 
-  if (imgUrl) {
-    if (imgUrl.startsWith('https://ipfs.paytaca.com/ipfs')) {
-      return imgUrl + '?pinataGatewayToken=' + process.env.PINATA_GATEWAY_TOKEN
-    } else {
-      return imgUrl
-    }
-  } else {
-    return generateFallbackImage(nft)
-  }
-}
+// function getImageUrl (nft) {
+//   const imgUrl = nft?.parsedMetadata?.imageUrl 
+//   if (imgUrl) {
+//     if (imgUrl.startsWith('https://ipfs.paytaca.com/ipfs')) {
+//       return imgUrl + '?pinataGatewayToken=' + process.env.PINATA_GATEWAY_TOKEN
+//     } else {
+//       return imgUrl
+//     }
+//   } else {
+//     return generateFallbackImage(nft)
+//   }
+// }
 </script>
 
 <style lang="scss" scoped>

--- a/src/wallet/cashtokens.js
+++ b/src/wallet/cashtokens.js
@@ -97,8 +97,8 @@ export class CashNonFungibleToken {
       name: this.parsedNftMetadata?.name || this.parsedGroupMetadata?.name,
       description: this.parsedNftMetadata?.description || this.parsedGroupMetadata?.description,
       symbol: this.parsedGroupMetadata?.symbol,
-      imageUrl: this.parsedNftMetadata?.imageUrl || this.parsedGroupMetadata?.imageUrl,
-      imageUrlFull: this.parsedNftMetadata?.imageUrlFull || this.parsedGroupMetadata?.imageUrl,
+      imageUrl: this.parsedNftMetadata?.imageUrl || this.parsedGroupMetadata?.imageUrl || this.metadata?.uris?.icon,
+      imageUrlFull: this.parsedNftMetadata?.imageUrlFull || this.parsedGroupMetadata?.imageUrl || this.metadata?.uris?.icon,
       attributes: this.parsedNftMetadata?.attributes,
     }
   }
@@ -131,7 +131,6 @@ export class CashNonFungibleToken {
   async fetchMetadata() {
     let url = `tokens/${this.category}/`
     if (this.commitment) url += `${this.commitment}/`
-    
     this.$state.fetchingMetadata = true
     return getBcmrBackend().get(url)
       .then(response => {


### PR DESCRIPTION
## Description
This change will add a fallback to the image url src in Collectibles.

Fixes # Issue raised by Hamza on Cashtokens Studio telegram group. In a direct msg to me he said he can see his NFT's images in Tapswap but not on Paytaca.

## Screenshots (if applicable):


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Hardcoded Hamza's tokenid as value of ```${this.category}``` in the ```fetchMetadata``` function in ```wallet/cashtokens.js```, images are now showing after applying the fix.

Will the applied changes affect other areas of the code? Will the applied changes affect functionalities of other features?
No


## @mentions
Mention the person or team responsible for reviewing the proposed changes.
