### PR TITLE
Fix/send page form disappearing inputs

### DIFF
--- a/src/components/send-page/SendPageForm.vue
+++ b/src/components/send-page/SendPageForm.vue
@@ -80,66 +80,64 @@
       </template>
     </q-input>
   </div>
-  <template v-if="$store.state.global.online !== false">
-    <div class="row" v-if="!isNFT">
-      <div class="col q-mt-xs">
-        <q-input
-          type="text"
-          inputmode="none"
-          filled
-          v-model="amountFormatted"
-          ref="amountInput"
-          class="bch-input-field"
-          @focus="onInputFocus(index, 'bch')"
-          :label="$t('Amount')"
-          :dark="darkMode"
-          :loading="computingMax"
-          :disabled="recipient.fixedAmount || inputExtras.isBip21"
-          :readonly="recipient.fixedAmount || inputExtras.isBip21"
-          :error="balanceExceeded"
-          :error-message="balanceExceeded ? $t('BalanceExceeded') : ''"
-          :key="inputExtras.amountFormatted"
-        >
-          <template v-slot:append>
-            {{ asset.id === 'bch' ? selectedDenomination : asset.symbol }}
-            <DenominatorTextDropdown
-              v-if="!recipient.fixedAmount"
-              @on-selected-denomination="onSelectedDenomination"
-              :selectedNetwork="asset.symbol"
-              :darkMode="darkMode"
-              :theme="theme"
-              :currentCountry="currentCountry"
-            />
-          </template>
-        </q-input>
-      </div>
+  <div class="row" v-if="!isNFT">
+    <div class="col q-mt-xs">
+      <q-input
+        type="text"
+        inputmode="none"
+        filled
+        v-model="amountFormatted"
+        ref="amountInput"
+        class="bch-input-field"
+        @focus="onInputFocus(index, 'bch')"
+        :label="$t('Amount')"
+        :dark="darkMode"
+        :loading="computingMax"
+        :disabled="recipient.fixedAmount || inputExtras.isBip21"
+        :readonly="recipient.fixedAmount || inputExtras.isBip21"
+        :error="balanceExceeded"
+        :error-message="balanceExceeded ? $t('BalanceExceeded') : ''"
+        :key="inputExtras.amountFormatted"
+      >
+        <template v-slot:append>
+          {{ asset.id === 'bch' ? selectedDenomination : asset.symbol }}
+          <DenominatorTextDropdown
+            v-if="!recipient.fixedAmount"
+            @on-selected-denomination="onSelectedDenomination"
+            :selectedNetwork="asset.symbol"
+            :darkMode="darkMode"
+            :theme="theme"
+            :currentCountry="currentCountry"
+          />
+        </template>
+      </q-input>
     </div>
+  </div>
 
-    <div class="row" v-if="!isNFT && asset.id === 'bch'">
-      <div class="col q-mt-xs">
-        <q-input
-          type="text"
-          inputmode="none"
-          filled
-          v-model="sendAmountInFiat"
-          ref="fiatInput"
-          class="fiat-input-field"
-          @focus="onInputFocus(index, 'fiat')"
-          :disabled="recipient.fixedAmount || inputExtras.isBip21"
-          :readonly="recipient.fixedAmount || inputExtras.isBip21"
-          :error="balanceExceeded"
-          :error-message="balanceExceeded ? $t('BalanceExceeded') : ''"
-          :label="$t('Amount')"
-          :dark="darkMode"
-          :key="inputExtras.sendAmountInFiat"
-        >
-          <template v-slot:append>
-            {{ String(currentSendPageCurrency()).toUpperCase() }}
-          </template>
-        </q-input>
-      </div>
+  <div class="row" v-if="!isNFT && asset.id === 'bch'">
+    <div class="col q-mt-xs">
+      <q-input
+        type="text"
+        inputmode="none"
+        filled
+        v-model="sendAmountInFiat"
+        ref="fiatInput"
+        class="fiat-input-field"
+        @focus="onInputFocus(index, 'fiat')"
+        :disabled="recipient.fixedAmount || inputExtras.isBip21"
+        :readonly="recipient.fixedAmount || inputExtras.isBip21"
+        :error="balanceExceeded"
+        :error-message="balanceExceeded ? $t('BalanceExceeded') : ''"
+        :label="$t('Amount')"
+        :dark="darkMode"
+        :key="inputExtras.sendAmountInFiat"
+      >
+        <template v-slot:append>
+          {{ String(currentSendPageCurrency()).toUpperCase() }}
+        </template>
+      </q-input>
     </div>
-  </template>
+  </div>
 
   <div class="row" v-if="!isNFT && !recipient.fixedAmount" style="padding-bottom: 15px">
     <div class="col q-mt-md balance-max-container" :class="getDarkModeClass(darkMode)">

--- a/src/pages/transaction/select-asset-send.vue
+++ b/src/pages/transaction/select-asset-send.vue
@@ -113,6 +113,9 @@ export default {
     isChipnet () {
       return this.$store.getters['global/isChipnet']
     },
+    online () {
+      return this.$store.state.global.online
+    },
     selectedNetwork: {
       get () {
         return this.$store.getters['global/network']
@@ -168,17 +171,28 @@ export default {
       }
     },
     redirectToSend (asset) {
-      const query = {
-        assetId: asset.id,
-        tokenType: 1,
-        network: this.selectedNetwork,
-        address: this.address,
-        backPath: this.backPath
+      if (this.online) {
+        const query = {
+          assetId: asset.id,
+          tokenType: 1,
+          network: this.selectedNetwork,
+          address: this.address,
+          backPath: this.backPath
+        }
+        this.$router.push({
+          name: 'transaction-send',
+          query
+        })
+      } else {
+        this.$q.dialog({
+          title: this.$t('Warning'),
+          message: this.$t('SendPageOffline'),
+          persistent: true,
+          seamless: true,
+          ok: true,
+          class: `pt-card no-click-outside text-bow ${this.getDarkModeClass(this.darkMode)}`
+        })
       }
-      this.$router.push({
-        name: 'transaction-send',
-        query
-      })
     }
   },
   async mounted () {


### PR DESCRIPTION
## Description
This PR will introduce a fix for a bug wherein the amount inputs in send page sometimes disappears. This is caused by an outdated checking of app online status. This fixes said issue by removing the outdated logic from the send page form amount inputs and elevating it to during selection of asset to prevent users to enter the send page form when it detects that the app is offline.


## Screenshots (if applicable):
- warning dialog when clicking on an asset while app is not online
![image](https://github.com/user-attachments/assets/4bc1239e-d164-46c4-9bd1-da22766ac290)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
The fix was tested on local environment by turning internet connectivity on and off; also tested with and without VPN enabled.
