### PR TITLE
Improvements/price chart

### DIFF
--- a/src/pages/transaction/dialog/PriceChart.vue
+++ b/src/pages/transaction/dialog/PriceChart.vue
@@ -76,10 +76,29 @@ export default {
       const vm = this
       // vm.isloaded = false
       vm.networkError = false
-      const url = 'https://api.coingecko.com/api/v3/coins/bitcoin-cash/market_chart?vs_currency=' + vm.selectedCurrency + '&days=1'
 
-      // request Data
-      const resp = await vm.$axios.get(url)
+      let apiPromise
+      if (vm.selectedCurrency === 'ars') {
+        apiPromise = vm.$axios.get(
+          'http://localhost:8000/api/price-chart/BCH/',
+          { params: { days: 1, vs_currency: vm.selectedCurrency.toUpperCase() } },
+        ).then(response => {
+          if (!Array.isArray(response.data)) return Promise.reject({ response })
+
+          response.data = {
+            prices: response.data.map(_data => {
+              return [parseInt(_data.timestamp), parseFloat(_data.price_value)]
+            })
+          }
+          return response
+        })
+      } else {
+        const url = 'https://api.coingecko.com/api/v3/coins/bitcoin-cash/market_chart?vs_currency=' + vm.selectedCurrency + '&days=1'
+        // request Data
+        apiPromise = vm.$axios.get(url)
+      }
+
+      const resp = await apiPromise
         .catch(function () {
           vm.networkError = true
           vm.isloaded = true

--- a/src/pages/transaction/dialog/PriceChart.vue
+++ b/src/pages/transaction/dialog/PriceChart.vue
@@ -39,6 +39,9 @@
             <canvas ref="chart"></canvas>
           </div>
         </q-card>
+        <div v-if="source" class="q-px-md text-right text-caption">
+          Source: {{ source }}
+        </div>
       </div>
     </q-card>
   </q-dialog>
@@ -57,6 +60,7 @@ export default {
       isloaded: false,
       date: [],
       bchPrice: [],
+      source: '', // 'coingecko' | 'watchtower'
       networkError: false,
       timer: '',
       priceChart: null,
@@ -79,6 +83,7 @@ export default {
 
       let apiPromise
       if (vm.selectedCurrency === 'ars') {
+        vm.source = 'Watchtower.cash'
         apiPromise = vm.$axios.get(
           'http://localhost:8000/api/price-chart/BCH/',
           { params: { days: 1, vs_currency: vm.selectedCurrency.toUpperCase() } },
@@ -93,6 +98,7 @@ export default {
           return response
         })
       } else {
+        vm.source = 'Coingecko'
         const url = 'https://api.coingecko.com/api/v3/coins/bitcoin-cash/market_chart?vs_currency=' + vm.selectedCurrency + '&days=1'
         // request Data
         apiPromise = vm.$axios.get(url)

--- a/src/pages/transaction/dialog/PriceChart.vue
+++ b/src/pages/transaction/dialog/PriceChart.vue
@@ -85,7 +85,7 @@ export default {
       if (vm.selectedCurrency === 'ars') {
         vm.source = 'Watchtower.cash'
         apiPromise = vm.$axios.get(
-          'http://localhost:8000/api/price-chart/BCH/',
+          'https://watchtower.cash/api/price-chart/BCH/',
           { params: { days: 1, vs_currency: vm.selectedCurrency.toUpperCase() } },
         ).then(response => {
           if (!Array.isArray(response.data)) return Promise.reject({ response })


### PR DESCRIPTION
## Description
- Changed price chart data source for ARS currency to watchtower.cash due to coingecko having incorrect price values to ARS.
  - Added price data source text below chart

Acceptance criteria for the issue or task could also be included here.

Fixes # (issue)
[Bug #70](https://scibizinformatics.slack.com/lists/T04RT6J7G/F07N8SDNF6V?record_id=Rec08DT1H4E6L)

## Screenshots (if applicable):
![ARS price chart](https://github.com/user-attachments/assets/98e62c71-5154-4c8e-8558-f2e7c4244728)
![Other price chart (PHP)](https://github.com/user-attachments/assets/71e7f7b0-1a53-49b4-94f9-62ade2bcf348)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Compare fiat value of balance in BCH card with manual calculation
  - Changed currency to ARS
  - Multiplied balance & with price displayed in chart to calculate
  - Will require changes from [backend](https://github.com/paytaca/watchtower-cash/pull/356) to be deployed

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
