### PR TITLE
Improvement/receive input amount field

### DIFF
--- a/src/pages/transaction/receive.vue
+++ b/src/pages/transaction/receive.vue
@@ -707,6 +707,24 @@ export default {
     },
     amountDialog () {
       this.tempAmount = this.amount
+    },
+    setAmountInFiat(newVal, oldVal) {
+      const amount = parseFloat(this.amountDialog ? this.tempAmount : this.amount)
+      if (!amount) return
+
+      let newAmount
+      if (newVal && !oldVal) {
+        newAmount = amount * this.selectedAssetMarketPrice
+      } else if (!newVal && oldVal) {
+        newAmount = amount / this.selectedAssetMarketPrice
+      } else {
+        newAmount = amount
+      }
+
+      const decimals = newVal ? 3 : parseInt(this.asset?.decimals) || 8
+      const newParsedAmount = String(parseFloat(newAmount.toFixed(decimals)))
+      this.amount = newParsedAmount
+      this.tempAmount = newParsedAmount
     }
   },
 

--- a/src/pages/transaction/receive.vue
+++ b/src/pages/transaction/receive.vue
@@ -4,7 +4,7 @@
       :title="$t('Receive') + ' ' + asset.symbol"
       backnavpath="/receive/select-asset"
     ></header-nav>
-    <div v-if="!amountDialog">
+    <div v-if="!amountDialog" class="text-bow" :class="getDarkModeClass(darkMode)">
       <q-icon
         v-if="!isSep20"
         id="context-menu"
@@ -161,6 +161,9 @@
             :label="$t('Amount')"
             :readonly="readonlyState"
             :dark="darkMode"
+            :rules="[
+              val => Boolean(val) || $t('InvalidAmount'),
+            ]"
           >
             <template v-slot:append>
               <div class="q-pr-sm text-weight-bold" style="font-size: 15px;">


### PR DESCRIPTION
## Description
- Display error message when amount field is blank
- Convert input amount between fiat & BCH when toggling fiat/bch amount

Fixes # (issue)
[Bug #42](https://scibizinformatics.slack.com/lists/T04RT6J7G/F07N8SDNF6V?record_id=Rec07T9D36882)

## Screenshots (if applicable):
![image](https://github.com/user-attachments/assets/07601318-fd86-49a9-904c-ba8a716a3dc4)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Tested blank input when updating amount to check if error message is displayed
- Toggle between BCH/fiat to check if amount is being converted

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
