### PR TITLE
Fix/unknown qr code error

### DIFF
--- a/src/pages/qr/qr-reader.vue
+++ b/src/pages/qr/qr-reader.vue
@@ -79,6 +79,7 @@ import LoadingWalletDialog from 'src/components/multi-wallet/LoadingWalletDialog
 import QRUploader from 'src/components/QRUploader'
 import { parseWalletConnectUri } from 'src/wallet/walletconnect'
 import { isTokenAddress } from 'src/utils/address-utils';
+import { parseAddressWithoutPrefix } from 'src/utils/send-page-utils'
 
 export default {
   name: 'QRReader',
@@ -249,7 +250,9 @@ export default {
       const vm = this
 
       if (content) {
-        const value = content[0].rawValue
+        const _value = content[0].rawValue
+        const addressValidation = parseAddressWithoutPrefix(_value)
+        const value = addressValidation?.valid ? addressValidation.address : _value
 
         vm.paused = true
         // quick timeout to allow qrcode stream cache to reset after pausing

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -694,6 +694,16 @@ export default {
       let fungibleTokenAmount = null
       let paymentUriData = null
 
+      const prefixlessAddressValidation = sendPageUtils.parseAddressWithoutPrefix(content)
+      if (prefixlessAddressValidation.valid) {
+        return [
+          prefixlessAddressValidation.address,
+          null,
+          null,
+          null,
+        ]
+      }
+
       try {
         paymentUriData = parsePaymentUri(
           content,

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -703,7 +703,10 @@ export default {
         if (paymentUriData?.outputs?.length > 1) throw new Error('InvalidOutputCount')
       } catch (error) {
         console.error(error)
-        sendPageUtils.paymentUriPromiseResponseHandler(error)
+        sendPageUtils.paymentUriPromiseResponseHandler(
+          error,
+          { defaultError: this.$t('UnidentifiedQRCode') },
+        )
         return
       }
 

--- a/src/utils/send-page-utils.js
+++ b/src/utils/send-page-utils.js
@@ -7,6 +7,7 @@ import { JSONPaymentProtocol } from 'src/wallet/payment-uri'
 import { isValidTokenAddress } from 'src/wallet/chipnet'
 import { isTokenAddress } from 'src/utils/address-utils'
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
+import { CashAddressType, decodeCashAddress, decodeCashAddressFormatWithoutPrefix, encodeCashAddress } from '@bitauth/libauth'
 
 const { t: $t } = i18n.global
 
@@ -156,6 +157,27 @@ export function validateAddress (address, walletType, isCashToken) {
 
   return { valid: addressIsValid, address: formattedAddress }
 }
+
+/**
+ * Will parse address with or without prefix, returns address with the prefix if it was missing
+ * @param {String} prefixlessAddress 
+ * @returns 
+ */
+export function parseAddressWithoutPrefix(prefixlessAddress) {
+  if (typeof prefixlessAddress !== 'string') return {valid: false, error: 'Invalid address' }
+
+  const resultWPrefix = decodeCashAddress(prefixlessAddress)
+  if (typeof resultWPrefix !== 'string') return { valid: true, address: prefixlessAddress }
+
+  const result = decodeCashAddressFormatWithoutPrefix(prefixlessAddress)
+  if (typeof result === 'string') return { valid: false, error: result }
+
+  return {
+    valid: true,
+    address: `${result.prefix}:${prefixlessAddress}`,
+  }
+}
+
 
 export function raiseNotifyError (message) {
   Notify.create({

--- a/src/utils/send-page-utils.js
+++ b/src/utils/send-page-utils.js
@@ -166,13 +166,15 @@ export function raiseNotifyError (message) {
   })
 }
 
-export function paymentUriPromiseResponseHandler (error) {
+export function paymentUriPromiseResponseHandler (error, opts = { defaultError: '' }) {
   if (error?.message === 'PaymentRequestIsExpired') {
     raiseNotifyError($t(error.message))
   } else if (error?.message === 'InvalidOutputAddress' || error?.name === 'InvalidOutputAddress') {
     raiseNotifyError($t('InvalidAddressFormat'))
   } else if (error?.message === 'InvalidOutputCount' || error?.name === 'InvalidOutputCount') {
     raiseNotifyError($t('MultipleRecipientsUnsupported'))
+  } else if (opts?.defaultError) {
+    raiseNotifyError(opts?.defaultError)
   }
 }
 


### PR DESCRIPTION
## Description
- Show default error message when failing to parse qrcode content in send page
- Allowed addresses without prefixes as valid addresses in qr scanner and send page
  - Payment urls without prefixes (e.g. `qq4s...69g?amount=0.1`) is not recognized since BIP0021 requires prefixes

Fixes # (issue)
[Bug #72](https://scibizinformatics.slack.com/lists/T04RT6J7G/F07N8SDNF6V?record_id=Rec08D62TLWK1)

## Screenshots (if applicable):
![image1](https://github.com/user-attachments/assets/cb252d40-5605-4d91-8964-4f2463b18646)
![image2](https://github.com/user-attachments/assets/be089073-b435-4b52-bfa0-6fc5ae4bf59e)

![coinprocess.io qr](https://github.com/user-attachments/assets/20a4cc45-b97e-424e-ad29-15c9f8823666)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested scanning/uploading coinprocess.io [qrcode](https://coinprocess.io/pay/QEh3y9Tsu3tv7md) (see screenshots)

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
