### PR TITLE
fix dialog texts not visible on light mode

### DIFF
--- a/src/components/walletconnect/SelectAddressForSessionDialog.vue
+++ b/src/components/walletconnect/SelectAddressForSessionDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog ref="dialogRef" persistent seamless>
-    <q-card class="q-dialog-plugin br-15 q-pb-xs pt-card" :class="getDarkModeClass(darkMode)">
+    <q-card class="q-dialog-plugin br-15 q-pb-xs pt-card text-bow" :class="getDarkModeClass(darkMode)">
       <q-card-section class="text-grey-10">
         <div class="row items-start justify-start no-wrap q-gutter-x-sm">
           <PeerInfo v-if="sessionProposal?.proposer?.metadata" 

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -4,7 +4,7 @@
       <div class="col-xs-12 text-right q-mb-md">
         <!-- <q-btn icon="refresh" @click.stop="() => refreshComponent()" flat></q-btn> -->
         <q-btn icon="settings" flat dense>
-          <q-menu fit anchor="bottom start" self="top end" class="br-15 pt-card q-py-md" :class="getDarkModeClass(darkMode)">
+          <q-menu fit anchor="bottom start" self="top end" class="br-15 pt-card q-py-md text-bow" :class="getDarkModeClass(darkMode)">
             <q-item>
               <q-item-section>
                 {{ $t('AddressDisplayFormat') }}
@@ -567,7 +567,7 @@ const disconnectSession = async (activeSession) => {
           noCaps: true,
           label: $t('No')
         },
-        class: `br-15 pt-card text-caption ${getDarkModeClass(darkMode.value)}`
+        class: `br-15 pt-card text-caption text-bow ${getDarkModeClass(darkMode.value)}`
       }).onOk(() => resolve()).onCancel(() => reject())
     }) 
 


### PR DESCRIPTION
## Description
Styling modification of wallet connect dialogs. 

Fixes # (issue)
Some wallet connect dialog texts aren't visible on light mode. Reported by @molecular.

## Type of Change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Checked problematic dialogs on light and dark mode.