### PR TITLE
Fix/bchjs minify bug

### DIFF
--- a/quasar.config.cjs
+++ b/quasar.config.cjs
@@ -13,6 +13,8 @@
 // Updated @quasar/app-webpack from 3.x.x to 4.x.x to support bex manifest v3
 // https://quasar.dev/quasar-cli-webpack/upgrade-guide
 const { defineConfig } = require('#q-app/wrappers')
+const TerserPlugin = require('terser-webpack-plugin');
+
 
 module.exports = defineConfig((ctx) => {
   return {
@@ -151,6 +153,29 @@ module.exports = defineConfig((ctx) => {
               }
             }
           })
+        }
+
+        if (cfg.mode === 'production') {
+          const index = cfg.optimization.minimizer.findIndex((plugin) => {
+            return plugin instanceof TerserPlugin
+          })
+
+          // not setting 'mangle: false' breaks bchjs, HdNode.toXPubKey()
+          if (index >= 0) {
+            cfg.optimization.minimizer[index].options.minimizer.options.mangle = false
+          } else {
+            // Add custom TerserPlugin options
+            cfg.optimization.minimizer[index] = new TerserPlugin({
+              terserOptions: {
+                compress: {
+                  // Disable class renaming
+                  keep_classnames: true,
+                  keep_fnames: true,
+                },
+                mangle: false,
+              },
+            })
+          }
         }
 
         cfg.experiments = {


### PR DESCRIPTION
## Description
Fixed errors on pubkey & signing using bchjs throughout the app. Disabled identifier mangling in the minifier during build due to bchjs uses typeforce to check constructor names of public ECPair instances. This was explicitly disabled since the new app/webpack version enabled mangling by default.

Fixes # (issue)
n/a

## Screenshots (if applicable):
n/a


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested creating/importing wallet which previously failed during xpubkey generation.

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
