### PR TITLE
apply certain css properties for bottom-class to ios only

### DIFF
--- a/src/css/shared.scss
+++ b/src/css/shared.scss
@@ -142,11 +142,19 @@ div#q-app:has(.marketplace-container) {
   background-color: rgba($color: #000000, $alpha: 0.3)
 }
 
-@mixin bottom-card($height-percentage) {
-  position: fixed;
-  bottom: 0;
+@mixin bottom-card--base {
   width: 100%;
   max-height: 100vh;
+  body.platform-ios & {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    max-height: 100vh;
+  }
+}
+
+@mixin bottom-card($height-percentage) {
+  @include bottom-card--base;
   height: calc(#{$height-percentage} - env(safe-area-inset-bottom));
 }
 


### PR DESCRIPTION
## Description
- remove bottom excess space on bottom cards on non ios platforms
- restored popup animation on some card dialog

## Screenshots (if applicable):
![image](https://github.com/user-attachments/assets/11b9636f-c275-4986-9df6-8e2fa7e69c8b)
![image](https://github.com/user-attachments/assets/634fea31-6b4b-4c1a-b604-ab632b370421)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested cards with .bottom-card class (e.g. marketplace map dialogs, card dialog)

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
