### PR TITLE
Fix/app lag

### DIFF
--- a/src/components/multi-wallet/index.vue
+++ b/src/components/multi-wallet/index.vue
@@ -265,7 +265,10 @@ export default {
   async mounted () {
     const vm = this
 
-    vm.$store.dispatch('assets/updateVaultBchBalances', { chipnet: vm.isChipnet })?.catch(console.error)
+    vm.$store.dispatch('assets/updateVaultBchBalances', {
+      chipnet: vm.isChipnet,
+      excludeCurrentIndex: true,
+    })?.catch(console.error)
 
     // double checking if vault is empty
     await vm.$store.dispatch('global/saveExistingWallet')

--- a/src/pages/transaction/index.vue
+++ b/src/pages/transaction/index.vue
@@ -1584,11 +1584,6 @@ export default {
       vm.loadWallets()
     }
 
-    // If asset prices array is empty, immediately fetch asset prices
-    if (vm.$store.state.market.assetPrices.length === 0) {
-      vm.$store.dispatch('market/updateAssetPrices', {})
-    }
-
     const assets = vm.$store.getters['assets/getAssets']
     assets.forEach(a => vm.$store.dispatch('assets/getAssetMetadata', a.id))
 

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -1311,15 +1311,25 @@ export default {
   },
 
   async beforeMount () {
+    const loadTasks = []
+
+    if (Object.keys(vm.$store.getters['global/lastAddressAndIndex'] || {}).length === 0) {
+      loadTasks.push(vm.$store.dispatch('global/loadWalletLastAddressIndex'))
+    }
+    if (!vm.$store.getters['global/walletConnectedApps']) {
+      loadTasks.push(vm.$store.dispatch('global/loadWalletConnectedApps'))
+    }
+    if (!vm.$store.getters['global/walletAddresses']) {
+      loadTasks.push(vm.$store.dispatch('global/loadWalletAddresses'))
+    }
+
+    if (this.assetId === 'bch') return
     const dialog = this.$q.dialog({
       component: LoadingWalletDialog,
       componentProps: { loadingText: this.$t('ProcessingNecessaryDetails') }
     })
-    await Promise.all([
-      this.$store.dispatch('global/loadWalletLastAddressIndex'),
-      this.$store.dispatch('global/loadWalletAddresses'),
-      this.$store.dispatch('global/loadWalletConnectedApps'),
-    ])
+
+    await Promise.allSettled(loadTasks)
     dialog.hide()
   },
 
@@ -1358,16 +1368,6 @@ export default {
 
     if (this.inputExtras.length === 1) {
       this.inputExtras[0].selectedDenomination = this.denomination
-    }
-
-    if (Object.keys(vm.$store.getters['global/lastAddressAndIndex'] || {}).length === 0) {
-      await vm.$store.dispatch('global/loadWalletLastAddressIndex')
-    }
-    if (!vm.$store.getters['global/walletConnectedApps']) {
-      await vm.$store.dispatch('global/loadWalletConnectedApps')
-    }
-    if (!vm.$store.getters['global/walletAddresses']) {
-      await vm.$store.dispatch('global/loadWalletAddresses')
     }
   },
 

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -1323,7 +1323,6 @@ export default {
       loadTasks.push(vm.$store.dispatch('global/loadWalletAddresses'))
     }
 
-    if (this.assetId === 'bch') return
     const dialog = this.$q.dialog({
       component: LoadingWalletDialog,
       componentProps: { loadingText: this.$t('ProcessingNecessaryDetails') }

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -1315,9 +1315,11 @@ export default {
       component: LoadingWalletDialog,
       componentProps: { loadingText: this.$t('ProcessingNecessaryDetails') }
     })
-    await this.$store.dispatch('global/loadWalletLastAddressIndex')
-    await this.$store.dispatch('global/loadWalletAddresses')
-    await this.$store.dispatch('global/loadWalletConnectedApps')
+    await Promise.all([
+      this.$store.dispatch('global/loadWalletLastAddressIndex'),
+      this.$store.dispatch('global/loadWalletAddresses'),
+      this.$store.dispatch('global/loadWalletConnectedApps'),
+    ])
     dialog.hide()
   },
 

--- a/src/store/assets/actions.js
+++ b/src/store/assets/actions.js
@@ -1,8 +1,6 @@
 import { getMnemonic, Wallet } from '../../wallet'
 import { axiosInstance } from '../../boot/axios'
-import axios from 'axios'
-import { setupCache } from 'axios-cache-interceptor'
-import { convertIpfsUrl } from 'src/wallet/cashtokens'
+import { convertIpfsUrl, getBcmrBackend } from 'src/wallet/cashtokens'
 import {
   getWatchtowerApiUrl,
   getBlockChainNetwork,
@@ -10,19 +8,6 @@ import {
 } from 'src/wallet/chipnet'
 import Watchtower from 'watchtower-cash-js'
 
-
-function getBcmrBackend() {
-  const network = getBlockChainNetwork()
-  if (network === 'chipnet') {
-    return setupCache(axios.create({
-      baseURL: 'https://bcmr-chipnet.paytaca.com/api',
-    }))
-  } else {
-    return setupCache(axios.create({
-      baseURL: 'https://bcmr.paytaca.com/api',
-    }))
-  }
-}
 
 function getTokenIdFromAssetId (assetId) {
   const match = String(assetId).match(/^slp\/([0-9a-fA-F]+)$/)

--- a/src/store/assets/actions.js
+++ b/src/store/assets/actions.js
@@ -192,6 +192,7 @@ export async function saveExistingAsset (context, details) {
  * @param {Object} context 
  * @param {Object} opts 
  * @param {Boolean} opts.chipnet
+ * @param {Boolean} opts.excludeCurrentIndex
  */
 export async function updateVaultBchBalances(context, opts) {
   const watchtower = new Watchtower(opts?.chipnet)
@@ -208,6 +209,9 @@ export async function updateVaultBchBalances(context, opts) {
 
   const results = await Promise.allSettled(
     vault.map((assetsVault, index) => {
+      const walletIndex = context.rootGetters['global/getWalletIndex']
+      if (index === walletIndex && opts?.excludeCurrentIndex) return
+
       const assets = opts?.chipnet ? assetsVault?.chipnet_assets : assetsVault?.asset
 
       const bchAsset = assets?.find?.(asset => asset?.id === 'bch')

--- a/src/store/assets/mutations.js
+++ b/src/store/assets/mutations.js
@@ -200,17 +200,14 @@ export function updateAssetMetadata (state, data) {
   }
 
   if (!Array.isArray(assets)) return
+  if (!data) return
 
-  assets.forEach(a => {
-    if (a && data) {
-      if (a.id === data.id) {
-        a.name = data.name,
-        a.symbol = data.symbol,
-        a.decimals = data.decimals,
-        a.logo = data.logo || ''
-      }
-    }
-  })
+  const a = assets.find(a => a && a.id === data.id)
+
+  a.name = data.name,
+  a.symbol = data.symbol,
+  a.decimals = data.decimals,
+  a.logo = data.logo || ''
 }
 
 export function addRemovedAssetIds (state, data) {

--- a/src/store/assets/mutations.js
+++ b/src/store/assets/mutations.js
@@ -21,6 +21,28 @@ export function updateAssetBalance (state, data) {
 }
 
 /**
+ * 
+ * @param {*} state 
+ * @param {{ id: String, txCount?: Number}} data 
+ */
+export function updateAssetTxCount(state, data) {
+  const network = getBlockChainNetwork()
+  let assets = state.assets
+  if (network === 'chipnet') {
+    assets = state.chipnet__assets
+  }
+
+  for (let i = 0; i < assets.length; i++) {
+    const asset = assets[i]
+    if (asset?.id !== data.id) continue
+
+    const _txCount = parseInt(data.txCount)
+    asset.txCount = Number.isNaN(_txCount) ? undefined : _txCount
+    break;
+  }
+}
+
+/**
  *
  * @param {Object} state
  * @param {{ id:String, symbol:String, name:String, logo:String, balance: Number }} asset

--- a/src/utils/asset-utils.js
+++ b/src/utils/asset-utils.js
@@ -1,6 +1,15 @@
 import { getWalletByNetwork } from 'src/wallet/chipnet'
 
-export async function updateAssetBalanceOnLoad (id, wallet, store) {
+const balanceFetchMap = { /** id: Promise */}
+export async function updateAssetBalanceOnLoad(id, wallet, store) {
+  if (!balanceFetchMap[id]) {
+    balanceFetchMap[id] = _updateAssetBalanceOnLoad(id, wallet, store)
+      .finally(() => delete balanceFetchMap[id])
+  }
+  return balanceFetchMap[id]
+}
+
+async function _updateAssetBalanceOnLoad (id, wallet, store) {
   const tokenId = id.split('/')[1]
   const updateAssetBalance = 'assets/updateAssetBalance'
 

--- a/src/wallet/bch.js
+++ b/src/wallet/bch.js
@@ -1,28 +1,11 @@
 import Watchtower from 'watchtower-cash-js'
 import BCHJS from '@psf/bch-js'
 import sha256 from 'js-sha256'
-import { getWatchtowerApiUrl, getBlockChainNetwork, convertCashAddress } from './chipnet'
-import { convertIpfsUrl } from './cashtokens'
+import { getWatchtowerApiUrl, convertCashAddress } from './chipnet'
+import { convertIpfsUrl, getBcmrBackend } from './cashtokens'
 import { isTokenAddress } from '../utils/address-utils'
-import axios from 'axios'
 
 const bchjs = new BCHJS()
-
-import { setupCache } from 'axios-cache-interceptor';
-
-
-function getBcmrBackend() {
-  const network = getBlockChainNetwork()
-  if (network === 'chipnet') {
-    return setupCache(axios.create({
-      baseURL: 'https://bcmr-chipnet.paytaca.com/api',
-    }))
-  } else {
-    return setupCache(axios.create({
-      baseURL: 'https://bcmr.paytaca.com/api',
-    }))
-  }
-}
 
 
 export class BchWallet {

--- a/src/wallet/cashtokens.js
+++ b/src/wallet/cashtokens.js
@@ -2,17 +2,19 @@ import axios from "axios"
 import { getBlockChainNetwork } from './chipnet'
 import { setupCache } from 'axios-cache-interceptor'
 
+const BCMR_BACKEND_CHIP = setupCache(axios.create({
+  baseURL: 'https://bcmr-chipnet.paytaca.com/api',
+}))
+const BCMR_BACKEND_MAIN = setupCache(axios.create({
+  baseURL: 'https://bcmr.paytaca.com/api',
+}))
 
-function getBcmrBackend() {
+export function getBcmrBackend() {
   const network = getBlockChainNetwork()
   if (network === 'chipnet') {
-    return setupCache(axios.create({
-      baseURL: 'https://bcmr-chipnet.paytaca.com/api',
-    }))
+    return BCMR_BACKEND_CHIP
   } else {
-    return setupCache(axios.create({
-      baseURL: 'https://bcmr.paytaca.com/api',
-    }))
+    return BCMR_BACKEND_MAIN
   }
 }
 


### PR DESCRIPTION
## Description
- Fix incorrect setup of bcmr backend, causing fetching fetching token metadata not caching correctly
- Reduce delay noticed when selecting asset for receive caused by extra api call by skipping or caching result of api call. 
- Improved initialization of send page by removing redundancies, running tasks in parallel, and conditionally skipping unnecessary tasks.

Fixes # (issue)


## Screenshots (if applicable):
n/a


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Tested selecting asset for receive.
  - Delay should only be noticeable at most once when selected asset has zero balance and transactions.
  - Assets with balance should have no delay
- Tested routing to send page
- Checked switching between select asset for send & receive if api calls for fetching metadata for each asset happens more than once within a few minutes

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
