### PR TITLE
Improvements/rewards app

### DIFF
--- a/src/components/rewards/dialogs/PointsReceivedDialog.vue
+++ b/src/components/rewards/dialogs/PointsReceivedDialog.vue
@@ -19,15 +19,19 @@
 
       <div class="row justify-center text-center q-gutter-y-xs">
         <q-icon name="celebration" size="70px" color="green" />
-        <span class="text-body1 q-mt-md">
-          {{ $t('PointsReceivedDescription1') }}
-        </span>
-        <span v-if="hasReceivedCashinPoints" class="text-body1">
-          {{ $t('PointsReceivedDescription2') }}
-        </span>
-        <span class="text-body2 q-mt-md">
-          {{ $t('PointsReceivedDescription3') }}
-        </span>
+        <span
+          class="text-body1 q-mt-md"
+          v-html="parseHtmlText('PointsReceivedDescription1')"
+        />
+        <span
+          v-if="hasReceivedCashinPoints"
+          class="text-body1"
+          v-html="parseHtmlText('PointsReceivedDescription2')"
+        />
+        <span
+          class="text-body1 q-mt-md"
+          v-html="parseHtmlText('PointsReceivedDescription3')"
+        />
       </div>
     </q-card>
   </q-dialog>
@@ -51,7 +55,10 @@ export default {
   },
 
   methods: {
-    getDarkModeClass
+    getDarkModeClass,
+    parseHtmlText (text) {
+      return this.$t(text)
+    }
   }
 }
 </script>

--- a/src/pages/apps/rewards/index.vue
+++ b/src/pages/apps/rewards/index.vue
@@ -4,7 +4,7 @@
       class="apps-header"
       backnavpath="/apps"
       :title="$t('Rewards')"
-      :rewardsPage="'home'"
+      :rewardsPage="isPageLive ? 'home' : ''"
     />
 
     <template v-if="isPageLive">
@@ -138,8 +138,7 @@ export default {
     vm.isLoading = true
 
     // check if rewards page is already live
-    // vm.isPageLive = await getRewardsPageToggle().then(data => { return data.is_live })
-    vm.isPageLive = true
+    vm.isPageLive = await getRewardsPageToggle().then(data => { return data.is_live })
     if (vm.isPageLive) {
       // retrieve points from engagement-hub
       const keyPair = await getKeyPairFromWalletMnemonic()

--- a/src/pages/apps/rewards/promos/user-rewards.vue
+++ b/src/pages/apps/rewards/promos/user-rewards.vue
@@ -152,17 +152,7 @@
                         />
                         <div class="col-10">
                           <template v-if="item.ref_id !== '' && item.date != ''">
-                            {{ $t(
-                                'EarnedFirstSeven',
-                                {
-                                  pointsEarned: item.points_earned,
-                                  refId: item.ref_id,
-                                  date: item.date
-                                },
-                                `Earned <strong>${item.points_earned}</strong> from `
-                                  + `${item.ref_id} last ${parseLocaleDate(item.date)}`
-                              )
-                            }}
+                            <span v-html="firstSevenHtmlText(item)" />
                           </template>
                           <span
                             v-else
@@ -449,6 +439,18 @@ export default {
         vm.points = await vm.urContract.getTokenBalance()
         vm.isLoading = false
       })
+    },
+    firstSevenHtmlText (item) {
+      return this.$t(
+        'EarnedFirstSeven',
+        {
+          pointsEarned: item.points_earned,
+          refId: item.ref_id,
+          date: this.parseLocaleDate(item.date)
+        },
+        `Earned <strong>${item.points_earned}</strong> from `
+          + `${item.ref_id} last ${this.parseLocaleDate(item.date)}`
+      )
     }
   }
 }

--- a/src/utils/engagementhub-utils/rewards.js
+++ b/src/utils/engagementhub-utils/rewards.js
@@ -66,10 +66,13 @@ export async function getWalletTokenAddress () {
 
 export function convertPoints (points, pointsDivisor) {
   const fiat = points / pointsDivisor
-  const bch = convertToBCH(denomination(), (fiat / bchMarketPrice()))
+  // use PHP for conversion basis
+  const phpFiat = Store.getters['market/getAssetPrice']('bch', 'PHP')
+  const bch = convertToBCH(denomination(), fiat / phpFiat)
 
-  const finalFiat = `${fiat} ${fiatCurrency()}`
+  const convertedFiat = Store.getters['market/getAssetPrice']('bch', fiatCurrency())
   const bchNum = Number(bch) === 0 || Number.isNaN(Number(bch)) ? '0' : bch.toFixed(8)
+  const finalFiat = `${(bchNum * convertedFiat).toFixed(2)} ${fiatCurrency()}`
   const finalBch = `${bchNum} ${denomination()}`
 
   return `${finalFiat} or ${finalBch}`

--- a/src/utils/rewards-utils/contracts/PromoContract.js
+++ b/src/utils/rewards-utils/contracts/PromoContract.js
@@ -14,7 +14,7 @@ import Watchtower from "watchtower-cash-js"
 import PromoContractCash from 'src/cashscripts/rewards/PromoContract.cash'
 
 const watchtower = new Watchtower(false)
-const promoTokens = 2
+const promoTokensDecimals = 2
 
 /**
  * Represents an instance of a promo contract. May vary
@@ -281,8 +281,7 @@ export default class PromoContract {
       })
       const promoToken = tokens.filter(t => t.category === process.env.PROMO_TOKEN_ID)
       if (promoToken.length > 0) {
-        balance = Number(promoToken[0].balance)
-        // balance = Number(promoToken[0].balance) / (10 ** promoTokens)
+        balance = Number(promoToken[0].balance) / (10 ** promoTokensDecimals)
       }
     }).catch(async _error => {
       // retrieve balance from contract token utxos
@@ -291,11 +290,8 @@ export default class PromoContract {
           return result.filter(r => r.token?.category === process.env.PROMO_TOKEN_ID)
         })
       balance = promoTokenUtxos.reduce((total, el) => {
-        return total + Number(el.token?.amount)
+        return total + (Number(el.token?.amount) / (10 ** promoTokensDecimals))
       }, 0)
-      // balance = promoTokenUtxos.reduce((total, el) => {
-      //   return total + (Number(el.token?.amount) / (10 ** promoTokens))
-      // }, 0)
     })
 
     return balance


### PR DESCRIPTION
## Description
This PR will introduce minor improvements and fixes to the Rewards page:
- adjust the display of points balance by introducing a decimal to the computation (since PTC has 2 decimals)
- fix parsing of translated texts with html tags in some components
- adjust the points conversion to bch and fiat, and made fiat conversion consistent regardless of selected currency
- fix static value assigned to isPageLive variable which shows the countdown timer


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Improvements


## Test Notes
Improvements and fixes were tested locally.
