### PR TITLE
Fix Exchange Chat Bug

### DIFF
--- a/src/components/ramp/fiat/dialogs/ChatDialog.vue
+++ b/src/components/ramp/fiat/dialogs/ChatDialog.vue
@@ -199,10 +199,8 @@
         dense
         v-model="message"
         :placeholder="$t('EnterMessage')"
-        @focus="()=> {
-          console.log($refs.container.$el)
-          let element = $refs.container.$el
-          console.log('element: ', element)
+        @focus="()=> {          
+          let element = $refs.container.$el          
 
           element.scrollTop = element.scrollHeight
         }"
@@ -459,8 +457,8 @@ export default {
   },
   async mounted () {
     // Set Data Here
-    const members = [this.order?.members?.buyer.public_key, this.order?.members?.seller.public_key].join('')
-    this.chatRef = generateChatRef(this.order?.id, this.order?.created_at, members)
+    const members = [this.order?.members?.buyer.public_key, this.order?.members?.seller.public_key].join('')    
+    this.chatRef = generateChatRef(this.order?.id, this.order?.created_at, members)    
     this.stopInfiniteScroll()
     this.loadKeyPair()
     this.loadChatSession()
@@ -541,8 +539,9 @@ export default {
     },
     async loadChatSession () {
       const vm = this
-      const chatIdentityRef = generateChatIdentityRef(wallet.walletHash)
-      vm.chatIdentity = this.$store.getters['ramp/chatIdentity'](chatIdentityRef)
+      const chatIdentityRef = generateChatIdentityRef(wallet.walletHash)      
+      vm.chatIdentity = this.$store.getters['ramp/chatIdentity'](chatIdentityRef)          
+
       let createSession = false
       await fetchChatSession(vm.chatRef)
         .catch(error => {
@@ -553,7 +552,7 @@ export default {
           } else {
             bus.emit('network-error')
           }
-        })
+        })      
       await vm.fetchOrderMembers(vm.order?.id).then(async (members) => {
         if (!['APL', 'RFN_PN', 'RLS_PN'].includes(this.order.status.value)) {
           members = members.filter(member => !member.is_arbiter)
@@ -564,19 +563,23 @@ export default {
         // Create session if necessary
         if (createSession) {
           await createChatSession(vm.order?.id, vm.chatRef).catch(error => { console.error(error) })
-          await updateChatMembers(vm.chatRef, chatMembers).catch(error => { console.error(error) })
+          await updateChatMembers(vm.chatRef, chatMembers).catch(error => { console.error(error) })          
         } else {
           // Add or update current chat members if any
           fetchChatMembers(vm.chatRef).then(async currentChatMembers => {
-            if (currentChatMembers?.length !== chatMembers?.length) {
-              const chatMemberIds = chatMembers.map(el => el.chat_identity_id)
+            let chatMemberIds = chatMembers.map(el => el.chat_identity_id)
+            chatMemberIds = chatMemberIds.filter(id => currentChatMembers.some(member => member.chat_identity.id === id))
+            
+            // if (currentChatMembers?.length !== chatMembers?.length) {
+            if (currentChatMembers?.length !== chatMemberIds?.length) {              
+              // const chatMemberIds = chatMembers.map(el => el.chat_identity_id)
               const membersToRemove = (currentChatMembers.filter(function (member) {
                 return !chatMemberIds.includes(member.chat_identity.id)
-              })).map(el => el.chat_identity.id)
+              })).map(el => el.chat_identity.id)              
               await updateChatMembers(vm.chatRef, chatMembers, membersToRemove).catch(error => { console.error(error) })
             }
           })
-        }
+        }        
         await fetchChatPubkeys(vm.chatRef).then(pubkeys => { vm.chatPubkeys = pubkeys }).catch(error => { console.error(error) })
         // Refetch updated chat members and format
         await fetchChatMembers(vm.chatRef)
@@ -593,8 +596,7 @@ export default {
                 pubkeys: member.chat_identity.pubkeys
               }
             })
-          })
-
+          })          
         // Fetch and decrypt messages
         fetchChatMessages(vm.chatRef)
           .then(async (data) => {
@@ -625,7 +627,7 @@ export default {
           } else {
             bus.emit('network-error')
           }
-        })
+        })        
     },
     fetchOrderMembers (orderId) {
       return new Promise((resolve, reject) => {

--- a/src/exchange/chat/index.js
+++ b/src/exchange/chat/index.js
@@ -12,6 +12,8 @@ export async function loadChatIdentity (usertype, params = { name: null, chat_id
   if (!params.name) throw new Error('missing required parameter: params.name')
   if (!wallet) await loadRampWallet()
 
+  const chatIDRef = generateChatIdentityRef(wallet.walletHash)  
+
   const payload = {
     user_type: usertype,
     name: params.name,
@@ -19,7 +21,10 @@ export async function loadChatIdentity (usertype, params = { name: null, chat_id
   }
 
   // fetch chat identity if existing
-  let identity = await fetchChatIdentityById(payload.chat_identity_id)
+
+  let identity = await fetchChatIdentityByRef(chatIDRef)
+  // let identity = await fetchChatIdentityById(payload.chat_identity_id)  
+
   if (identity) {
     identity = chatIdentityManager.setIdentity(identity)
   }
@@ -218,8 +223,7 @@ export async function updateChatMembers (chatRef, members, removeMemberIds = [])
       members: members
     }
     chatBackend.patch(`chat/sessions/${chatRef}/members/`, body, { forceSign: true })
-      .then(response => {
-        // console.log('Added chat members:', response)
+      .then(response => {        
         resolve(response)
       })
       .catch(error => {
@@ -274,7 +278,7 @@ export function sendChatMessage (data, signData) {
     }
     chatBackend.post('chat/messages/', data, config)
       .then(response => {
-        console.log('Sent message:', response)
+        // console.log('Sent message:', response)
         resolve(response)
       })
       .catch(error => {


### PR DESCRIPTION
## Description
Chat Identity ref fetched on watchtower does not match on the result of generateChatIdentityRef (current chat id generation method). Hence issue in accessing chat sessions on orders. 

Fixes # (issue)
- Uses chat Id ref generated from generateChatIdentityRef() function in fetching chat identity from commercehub. 
- If chat id ref not matching, create new chat identity and update it to watchtower.
- remove old chat id from chat session and add the new one.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Manual Testing

## @mentions
@joemarct 
