### PR TITLE
Bug fix: P2P Exchange Chat

### DIFF
--- a/src/components/ramp/fiat/dialogs/ChatDialog.vue
+++ b/src/components/ramp/fiat/dialogs/ChatDialog.vue
@@ -298,7 +298,7 @@ import { getDarkModeClass, isNotDefaultTheme } from 'src/utils/theme-darkmode-ut
 import { backend } from 'src/exchange/backend'
 import { getKeypair } from 'src/exchange/chat/keys'
 import { bus } from 'src/wallet/event-bus'
-import { elements } from 'chart.js'
+import { fetchUser } from 'src/exchange/auth'
 
 export default {
   directives: {
@@ -547,7 +547,9 @@ export default {
       // Create chat identity if it doesn't exist
       if (!vm.chatIdentity) {
         console.log('Creating chat identity')
-        loadChatIdentity(chatIdentityRef)
+        const user = await fetchUser()
+        console.log('User', user)
+        loadChatIdentity ('peer', { name: user?.name, chat_identity_id: user?.chat_identity_id })
           .then(identity => {
             vm.chatIdentity = identity
             this.$store.commit('ramp/updateChatIdentity', { ref: identity.ref, chatIdentity: identity })
@@ -577,6 +579,7 @@ export default {
         } else {
           vm.arbiterIdentity = members.filter(member => member.is_arbiter)[0]
         }
+        console.log('Chat members', members)
         const chatMembers = members.map(({ chat_identity_id }) => ({ chat_identity_id, is_admin: true }))
 
         // Create session if necessary

--- a/src/components/ramp/fiat/dialogs/ChatDialog.vue
+++ b/src/components/ramp/fiat/dialogs/ChatDialog.vue
@@ -199,8 +199,8 @@
         dense
         v-model="message"
         :placeholder="$t('EnterMessage')"
-        @focus="()=> {          
-          let element = $refs.container.$el          
+        @focus="()=> {
+          let element = $refs.container.$el
 
           element.scrollTop = element.scrollHeight
         }"
@@ -286,7 +286,8 @@ import {
   fetchChatMessages,
   generateChatRef,
   updateLastRead,
-  generateChatIdentityRef
+  generateChatIdentityRef,
+  loadChatIdentity
 } from 'src/exchange/chat'
 import { ChatMessage } from 'src/exchange/chat/objects'
 import { formatDate } from 'src/exchange'
@@ -457,8 +458,8 @@ export default {
   },
   async mounted () {
     // Set Data Here
-    const members = [this.order?.members?.buyer.public_key, this.order?.members?.seller.public_key].join('')    
-    this.chatRef = generateChatRef(this.order?.id, this.order?.created_at, members)    
+    const members = [this.order?.members?.buyer.public_key, this.order?.members?.seller.public_key].join('')
+    this.chatRef = generateChatRef(this.order?.id, this.order?.created_at, members)
     this.stopInfiniteScroll()
     this.loadKeyPair()
     this.loadChatSession()
@@ -539,9 +540,25 @@ export default {
     },
     async loadChatSession () {
       const vm = this
-      const chatIdentityRef = generateChatIdentityRef(wallet.walletHash)      
-      vm.chatIdentity = this.$store.getters['ramp/chatIdentity'](chatIdentityRef)          
+      const chatIdentityRef = generateChatIdentityRef(wallet.walletHash)
+      vm.chatIdentity = this.$store.getters['ramp/chatIdentity'](chatIdentityRef)
+      console.log('Chat Identity', vm.chatIdentity)
 
+      // Create chat identity if it doesn't exist
+      if (!vm.chatIdentity) {
+        console.log('Creating chat identity')
+        loadChatIdentity(chatIdentityRef)
+          .then(identity => {
+            vm.chatIdentity = identity
+            this.$store.commit('ramp/updateChatIdentity', { ref: identity.ref, chatIdentity: identity })
+            console.log('Chat Identity loaded', vm.chatIdentity)
+          })
+          .catch(error => {
+            console.error('Error loading chat identity:', error)
+          })
+      }
+
+      // Check if chat session exists
       let createSession = false
       await fetchChatSession(vm.chatRef)
         .catch(error => {
@@ -552,7 +569,8 @@ export default {
           } else {
             bus.emit('network-error')
           }
-        })      
+        })
+
       await vm.fetchOrderMembers(vm.order?.id).then(async (members) => {
         if (!['APL', 'RFN_PN', 'RLS_PN'].includes(this.order.status.value)) {
           members = members.filter(member => !member.is_arbiter)
@@ -560,34 +578,35 @@ export default {
           vm.arbiterIdentity = members.filter(member => member.is_arbiter)[0]
         }
         const chatMembers = members.map(({ chat_identity_id }) => ({ chat_identity_id, is_admin: true }))
+
         // Create session if necessary
         if (createSession) {
           await createChatSession(vm.order?.id, vm.chatRef).catch(error => { console.error(error) })
-          await updateChatMembers(vm.chatRef, chatMembers).catch(error => { console.error(error) })          
+          await updateChatMembers(vm.chatRef, chatMembers).catch(error => { console.error(error) })
         } else {
-          // Add or update current chat members if any
+          // Fetch current chat members and compare with provided members
           fetchChatMembers(vm.chatRef).then(async currentChatMembers => {
             let chatMemberIds = chatMembers.map(el => el.chat_identity_id)
             chatMemberIds = chatMemberIds.filter(id => currentChatMembers.some(member => member.chat_identity.id === id))
-            
-            // if (currentChatMembers?.length !== chatMembers?.length) {
-            if (currentChatMembers?.length !== chatMemberIds?.length) {              
-              // const chatMemberIds = chatMembers.map(el => el.chat_identity_id)
+
+            // If current chat members are not the same as chat members, update them
+            if (currentChatMembers?.length !== chatMemberIds?.length) {
               const membersToRemove = (currentChatMembers.filter(function (member) {
                 return !chatMemberIds.includes(member.chat_identity.id)
-              })).map(el => el.chat_identity.id)              
+              })).map(el => el.chat_identity.id)
               await updateChatMembers(vm.chatRef, chatMembers, membersToRemove).catch(error => { console.error(error) })
             }
           })
-        }        
+        }
+
         await fetchChatPubkeys(vm.chatRef).then(pubkeys => { vm.chatPubkeys = pubkeys }).catch(error => { console.error(error) })
-        // Refetch updated chat members and format
+
+        // Refetch and format the updated chat members
+        console.log('Fetching chat members')
         await fetchChatMembers(vm.chatRef)
           .then(members => {
-            // if mismatched name
             vm.chatMembers = members.map(member => {
               const name = this.$store.getters['ramp/getUser'].name
-
               return {
                 id: member.chat_identity.id,
                 name: member.chat_identity.ref === vm.chatIdentity.ref ? name : member.chat_identity.name,
@@ -596,17 +615,19 @@ export default {
                 pubkeys: member.chat_identity.pubkeys
               }
             })
-          })          
+            console.log('Chat members fetched', vm.chatMembers)
+          })
+
         // Fetch and decrypt messages
         fetchChatMessages(vm.chatRef)
           .then(async (data) => {
-            // set offset
             vm.totalMessages = data.count
             vm.offset += data.results.length
+
             const messages = data.results
             vm.convo.messages = messages.reverse()
+
             await vm.decryptMessages(messages)
-            // Update last read
             updateLastRead(vm.chatRef, vm.convo.messages).then(() => { bus.emit('last-read-update') })
           })
           .finally(() => {
@@ -627,7 +648,7 @@ export default {
           } else {
             bus.emit('network-error')
           }
-        })        
+        })
     },
     fetchOrderMembers (orderId) {
       return new Promise((resolve, reject) => {

--- a/src/exchange/auth.js
+++ b/src/exchange/auth.js
@@ -121,7 +121,7 @@ export class ExchangeUser {
   }
 }
 
-async function fetchUser () {
+export async function fetchUser () {
   const { data: userData } = await backend.get('/auth/')
   return new ExchangeUser(userData)
 }
@@ -129,12 +129,17 @@ async function fetchUser () {
 export async function loadAuthenticatedUser (forceLogin = false) {
   try {
     const user = await fetchUser()
+
     user.emitSignal(null, { signal: 'logging-in', data: true })
+
     await user.login(!user.is_authenticated || forceLogin)
     await Promise.all([user.fetchChatIdentity(), user.savePubkeyAndAddress()])
+
     user.emitSignal(null, { signal: 'logging-in', data: false })
+
     return Promise.resolve(user)
   } catch (error) {
+    console.error(error)
     bus.emit('logging-in', false)
     return Promise.reject(error)
   }

--- a/src/exchange/chat/index.js
+++ b/src/exchange/chat/index.js
@@ -7,12 +7,23 @@ import { loadRampWallet, wallet } from 'src/exchange/wallet'
 import { ChatIdentityManager } from './objects'
 
 export const chatIdentityManager = new ChatIdentityManager()
+
+/**
+ * Loads or creates a chat identity for a user
+ * @async
+ * @param {string} usertype - The type of user (required)
+ * @param {Object} params - Parameters for chat identity
+ * @param {string} params.name - The chat identity name of the user (required)
+ * @param {string|null} params.chat_identity_id - The ID of an existing chat identity, if any
+ * @throws {Error} Will throw an error if usertype or params.name is missing
+ * @returns {Promise<Object>} The loaded or created chat identity object
+ */
 export async function loadChatIdentity (usertype, params = { name: null, chat_identity_id: null }) {
   if (!usertype) throw new Error('missing required parameter: usertype')
   if (!params.name) throw new Error('missing required parameter: params.name')
   if (!wallet) await loadRampWallet()
 
-  const chatIDRef = generateChatIdentityRef(wallet.walletHash)  
+  // const chatIDRef = generateChatIdentityRef(wallet.walletHash)
 
   const payload = {
     user_type: usertype,
@@ -20,20 +31,19 @@ export async function loadChatIdentity (usertype, params = { name: null, chat_id
     chat_identity_id: params.chat_identity_id
   }
 
-  // fetch chat identity if existing
-
-  let identity = await fetchChatIdentityByRef(chatIDRef)
-  // let identity = await fetchChatIdentityById(payload.chat_identity_id)  
+  // let identity = await fetchChatIdentityByRef(chatIDRef)
+  // fetch chat identity if existing, will return null if not existing
+  let identity = await fetchChatIdentityById(payload.chat_identity_id)
 
   if (identity) {
     identity = chatIdentityManager.setIdentity(identity)
   }
 
-  // update verifying and encryption keypairs
-  await chatIdentityManager._updateSignerData() // (short-circuits when task is not necessary)
-  await chatIdentityManager._updateEncryptionKeypair(!!identity) // (short-circuits when task is not necessary)
+  // Update chat verifying and encryption keypairs (short-circuits when not necessary)
+  await chatIdentityManager._updateSignerData()
+  await chatIdentityManager._updateEncryptionKeypair(!!identity)
 
-  // create identity if not existing
+  // Create identity, if not existing
   if (!identity) {
     payload.ref = generateChatIdentityRef(wallet.walletHash)
     identity = await chatIdentityManager.create(payload)
@@ -126,6 +136,7 @@ export async function fetchChatIdentityByRef (ref) {
 }
 
 export async function fetchChatIdentityById (id) {
+  if (!id) return null
   return new Promise((resolve, reject) => {
     chatBackend.get(`chat/identities/${id}/`)
       .then(response => {
@@ -223,7 +234,7 @@ export async function updateChatMembers (chatRef, members, removeMemberIds = [])
       members: members
     }
     chatBackend.patch(`chat/sessions/${chatRef}/members/`, body, { forceSign: true })
-      .then(response => {        
+      .then(response => {
         resolve(response)
       })
       .catch(error => {
@@ -239,7 +250,7 @@ export async function updateChatMembers (chatRef, members, removeMemberIds = [])
 
 export async function fetchChatMembers (chatRef) {
   return new Promise((resolve, reject) => {
-    chatBackend.get(`chat/members/full_info/?chat_ref=${chatRef}`, { forceSign: true })
+    chatBackend.get(`chat/members/full_info/?chat_ref=${chatRef}`)
       .then(response => {
         // console.log('Fetched chat members:', response)
         resolve(response.data.results)
@@ -265,7 +276,6 @@ export async function updateLastRead (chatRef, messages) {
   }
   return chatBackend.post(`chat/sessions/${chatRef}/chat_member/`, data, { forceSign: true })
     .then(response => {
-      console.log('Updated last read timestamp:', data)
       return response
     })
 }

--- a/src/exchange/chat/index.js
+++ b/src/exchange/chat/index.js
@@ -11,7 +11,7 @@ export const chatIdentityManager = new ChatIdentityManager()
 /**
  * Loads or creates a chat identity for a user
  * @async
- * @param {string} usertype - The type of user (required)
+ * @param {string} usertype - The type of user (required) (valid values: peer | arbiter)
  * @param {Object} params - Parameters for chat identity
  * @param {string} params.name - The chat identity name of the user (required)
  * @param {string|null} params.chat_identity_id - The ID of an existing chat identity, if any


### PR DESCRIPTION
## Description
Bug fix: 
- Ensure chat identity is created if it does not exist when loading a chat session or creating an order.
- Also removed the unnecessary `X-Chat-Identity` header when fetching chat session members. While this endpoint doesn’t require the header, we recently encountered a case where it returned an "invalid auth header, chat identity not found" error. We’ve confirmed that the `chat_identity` does exist, so the cause is still unclear — possibly an issue with how the identity is resolved or a mismatch in the chat identity reference (though that also appears correct). Removing the header is an attempt to isolate and prevent this error, since the endpoint works without it.

## Screenshots (if applicable):
NA

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
How Has This Been Tested?

- Manually tested chat session loading across multiple user states (new user with no identity, returning user).
- Confirmed that chat session members are fetched successfully without the `X-Chat-Identity` header.
- Verified chat functionality still works end-to-end after the fix.

## @mentions
@joemarct 
