### PR TITLE
Improvements/token assets

### DIFF
--- a/src/components/notifications/index.vue
+++ b/src/components/notifications/index.vue
@@ -325,10 +325,9 @@ export default {
             vm.$router.push({ name: 'transaction-send', query })
           } else { // payment received notif
             const transactionDetails = notif.extra_data.split(';')
-            let tokenId = ''
-            if (transactionDetails[1] !== '1') { // token, not bch
-              const symbol = notif.message.split(' ').pop()
-              tokenId = this.mainchainAssets.find(a => a.symbol === symbol)?.id || ''
+            let tokenId = transactionDetails[1]
+            if (parseInt(tokenId) === 1) { // for backwards compatibility with bch notifs
+              tokenId = 'bch'
             }
 
             this.onOpenTransaction({

--- a/src/pages/transaction/dialog/AddNewAsset.vue
+++ b/src/pages/transaction/dialog/AddNewAsset.vue
@@ -227,6 +227,7 @@ export default {
 
       if (this.isSep20) {
         this.$store.commit('sep20/addNewAsset', this.asset)
+        this.$store.commit(`sep20/moveAssetToBeginning`)
         this.$store.dispatch('market/updateAssetPrices', { clearExisting: true })
         this.$store.dispatch('sep20/updateTokenIcon', { assetId: this.asset.id })
         return
@@ -242,6 +243,7 @@ export default {
           decimals: 0,
         }, this.asset, { balance: 0 })
       )
+      this.$store.commit(`assets/moveAssetToBeginning`)
     },
     onOKClick () {
       this.addAsset()

--- a/src/pages/transaction/index.vue
+++ b/src/pages/transaction/index.vue
@@ -1331,7 +1331,8 @@ export default {
         if (this.selectedNetwork != chain) this.changeNetwork(chain, asset)
         const refetchTxList = this.selectedAsset?.id != asset?.id
         if (refetchTxList) {
-          this.setSelectedAsset(asset)
+          if (asset?.id === 'bch') this.selectBch()
+          else this.setSelectedAsset(asset)
         }
       } else {
         transaction.asset = {

--- a/src/pages/transaction/index.vue
+++ b/src/pages/transaction/index.vue
@@ -1320,15 +1320,17 @@ export default {
         })
         return
       }
+
+      if (!asset?.id && tokenId.startsWith('ct/')) {
+        asset = await this.wallet.BCH.getTokenDetails(tokenId.split('/')[1])
+        this.$store.commit(`assets/addNewAsset`, asset)
+      }
+
       if (asset?.id) {
         if (this.selectedNetwork != chain) this.changeNetwork(chain, asset)
         const refetchTxList = this.selectedAsset?.id != asset?.id
-        this.selectedAsset = asset
         if (refetchTxList) {
-          this.transactions = []
-          this.transactionsPage = 0
-          this.transactionsLoaded = false
-          this.$refs['transaction-list-component'].getTransactions()
+          this.setSelectedAsset(asset)
         }
       } else {
         transaction.asset = {

--- a/src/pages/transaction/index.vue
+++ b/src/pages/transaction/index.vue
@@ -1324,6 +1324,7 @@ export default {
       if (!asset?.id && tokenId.startsWith('ct/')) {
         asset = await this.wallet.BCH.getTokenDetails(tokenId.split('/')[1])
         this.$store.commit(`assets/addNewAsset`, asset)
+        this.$store.commit(`assets/moveAssetToBeginning`)
       }
 
       if (asset?.id) {


### PR DESCRIPTION
## Description
- Move added tokens to front of assets list. [ref](https://t.me/PaytacaWalletApp/11703/12050)
- Auto add asset to list when opening cashtoken transaction with assets not yet in list. 

Fixes # (issue)
[Bug#101](https://scibizinformatics.slack.com/lists/T04RT6J7G/F07N8SDNF6V?record_id=Rec08VB4Z615G)

## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Manually add new fungible cashtoken.
  - Asset should show in front(left most) of list instead of last(right most)
- Opening cashtoken transactions from notifications dialog. (Might need notifs created after this [update](https://github.com/paytaca/watchtower-cash/pull/383))
  - Should not see transaction not found message anymore.
  - If token is not in assets list, it will be added to front of list

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
