### PR TITLE
Fix: Handle getKeypair failure and clean up migrated Vuex state

### DIFF
--- a/src/exchange/chat/index.js
+++ b/src/exchange/chat/index.js
@@ -354,10 +354,15 @@ export async function updateOrCreateKeypair (update = true) {
   const seed = await getKeypairSeed()
   const keypair = generateKeypair({ seed: seed })
 
-  const storedKeypair = await getKeypair()
-  if (storedKeypair.pubkey === keypair.pubkey && storedKeypair.privkey === keypair.privkey) {
-    console.log('Chat encryption keypair still updated')
-    return
+  try {
+    const storedKeypair = await getKeypair()
+    if (storedKeypair.pubkey === keypair.pubkey && storedKeypair.privkey === keypair.privkey) {
+      console.log('Chat encryption keypair still updated')
+      return
+    }
+
+  } catch (error) {
+    console.error(error)
   }
 
   if (update) {
@@ -376,6 +381,7 @@ export async function updateOrCreateKeypair (update = true) {
 
   return keypair
 }
+
 export function generateChatRef (id, createdAt, members) {
   if (!members) throw Error('Missing required value: members')
   const hashVal = id + createdAt + members

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,4 @@
 import { createStore } from 'vuex'
-import createPersistedState from 'vuex-persistedstate'
 import VuexPersistence from 'vuex-persist'
 import localforage from 'localforage'
 import { sanitizeForIndexedDB } from 'src/utils/migrate-localstorage-to-indexdb'

--- a/src/utils/migrate-localstorage-to-indexdb.js
+++ b/src/utils/migrate-localstorage-to-indexdb.js
@@ -52,7 +52,7 @@ export async function migrateVuexLocalStorage() {
       const sanitizedState = sanitizeForIndexedDB(migratedState)
       await localforage.setItem(key, sanitizedState)
       console.info('[Migration] Vuex state migrated to IndexedDB.')
-      // localStorage.removeItem(key) // optional: cleanup
+      localStorage.removeItem(key) // optional: cleanup
       window.localStorage.setItem(MIGRATION_FLAG, true) // Mark migration done
     } else {
       console.info('[Migration] No Vuex localStorage data to migrate.')


### PR DESCRIPTION
## Description
This PR includes the following changes:

- Catches and logs the error when `getKeypair` fails. This prevents the creation of the chat identity from being interrupted, which could otherwise cause issues in the chat functionality.
- Clears the migrated Vuex state from local storage to ensure a clean application state post-migration.

## Screenshots (if applicable):
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
How Has This Been Tested?

- Verified that getKeypair errors are now handled gracefully without breaking chat identity creation.
- Confirmed that migrated Vuex data is cleared from localStorage during initialization.
