### PR TITLE
Fix route exiting p2p exchange

### DIFF
--- a/src/pages/apps/exchange/peer_to_peer/index.vue
+++ b/src/pages/apps/exchange/peer_to_peer/index.vue
@@ -56,10 +56,19 @@ export default {
   beforeRouteEnter (to, from, next) {
     next(vm => {
       vm.previousRoute = from.path
+
+      // console.log('previous: ', vm.previousRoute)
       if (from.name === 'exchange') {
         vm.previousRoute = '/apps'
       }
     })
+  },
+  beforeRouteLeave (to, from, next) {    
+    if (to.name === 'exchange') {
+      this.$router.push({ name: 'apps-dashboard' })
+    } else {
+      next()
+    }    
   },
   computed: {
     multipleAdLimitMessage () {
@@ -73,14 +82,14 @@ export default {
     bus.on('session-expired', this.handleSessionEvent)
     bus.on('post-notice', this.postNotice)
     bus.on('handle-request-error', this.handleRequestError)
-  },
-  async mounted () {
+  },  
+  async mounted () {    
     await this.loadWallet()
     this.fetchUser()
     this.setupWebsocket()
   },
-  beforeUnmount () {
-    this.$q.loading.hide()
+  beforeUnmount () {    
+    this.$q.loading.hide()    
   },
   methods: {
     isNotDefaultTheme,


### PR DESCRIPTION
## Description
- After clicking mobile back button to exit p2p exchange, it sometimes get stuck on exchange blank page(where logging in takes place), instead of exiting to apps list page.

Fixes # (issue)
- added beforeRouteLeave component on p2p-exchange/index page to catch when it gets stuck on blank page(login page) and redirect to apps-dashboard

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested Manually

## @mentions
@joemarct 
