### PR TITLE
Re-enable push notifs boot file in quasar config

### DIFF
--- a/quasar.config.cjs
+++ b/quasar.config.cjs
@@ -39,7 +39,7 @@ module.exports = defineConfig((ctx) => {
       'i18n',
       'axios',
       'leaflet',
-      // 'push-notifications',
+      'push-notifications',
       'qrcodecomponent',
       'qrcodereader',
       'clipboard',


### PR DESCRIPTION
## Description
This PR will apply a fix to the infinite loading issue in the push notifications settings. The push notifications boot file was accidentally disabled in the quasar config, rendering the $pushNotifications global app config unusable.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
The PR was tested locally on an Android device.
