### PR TITLE
Fix wallet switching bug caused by unhydrated Vuex state on app start

### DIFF
--- a/src/boot/vuex.js
+++ b/src/boot/vuex.js
@@ -1,5 +1,6 @@
 import { boot } from 'quasar/wrappers'
 import { migrateVuexLocalStorage } from 'src/utils/migrate-localstorage-to-indexdb'
+import { hydrateWallet } from 'src/utils/wallet-hydration'
 import useStore from 'src/store'
 
 /**
@@ -16,6 +17,8 @@ export default boot(async (obj) => {
 
     const store = useStore();
     const { app } = obj
+
+    await hydrateWallet()
 
     // Add error handler for store mutations
     store.subscribe((mutation, state) => {

--- a/src/components/multi-wallet/BasicInfoDialog.vue
+++ b/src/components/multi-wallet/BasicInfoDialog.vue
@@ -23,6 +23,14 @@
         </q-item>
         <q-item>
           <q-item-section>
+            <q-item-label :class="{ 'text-blue-5': darkMode }" caption>{{ $t('WalletHash') }}</q-item-label>
+            <q-item-label class="pt-label" :class="getDarkModeClass(darkMode)" style="word-wrap: break-word;">
+              {{ walletInfo.wallet.bch.walletHash }}
+            </q-item-label>
+          </q-item-section>
+        </q-item>
+        <q-item>
+          <q-item-section>
             <q-item-label :class="{ 'text-blue-5': darkMode }" caption>{{ $t('WalletBalanceCap') }}</q-item-label>
             <q-item-label class="pt-label" :class="getDarkModeClass(darkMode)" style="word-wrap: break-word;">
               {{ parseAssetDenomination(denomination, getAssetData(), false, 10) }}<br/>
@@ -31,8 +39,8 @@
           </q-item-section>
         </q-item>
       </q-list>
-      <p class="q-ma-sm q-mt-lg section-title">{{ $t('BchAddresses') }}</p>
-      <q-list bordered separator class="br-12 pt-card-2" :class="getDarkModeClass(darkMode)">
+      <!-- <p class="q-ma-sm q-mt-lg section-title">{{ $t('BchAddresses') }}</p> -->
+      <!-- <q-list bordered separator class="br-12 pt-card-2" :class="getDarkModeClass(darkMode)">
         <q-item>
           <q-item-section>
             <q-item-label :class="{ 'text-blue-5': darkMode }" caption>{{ $t('DerivationPath') }}</q-item-label>
@@ -57,7 +65,7 @@
             </q-item-label>
           </q-item-section>
         </q-item>
-      </q-list>
+      </q-list> -->
     </q-card>
   </q-dialog>
 </template>

--- a/src/components/multi-wallet/BasicInfoDialog.vue
+++ b/src/components/multi-wallet/BasicInfoDialog.vue
@@ -108,9 +108,11 @@ export default {
     parseFiatCurrency,
     getAssetData () {
       const index = this.vaultIndex
+      const vault = this.$store.getters['assets/getVault']
+      if (!vault) return {}
       return this.isChipnet
-        ? this.$store.getters['assets/getVault'][index].chipnet_assets[0]
-        : this.$store.getters['assets/getVault'][index].asset[0]
+        ? vault[index].chipnet_assets[0]
+        : vault[index].asset[0]
     },
     getAssetMarketBalance (asset) {
       if (!asset?.id) return ''

--- a/src/components/multi-wallet/index.vue
+++ b/src/components/multi-wallet/index.vue
@@ -230,7 +230,9 @@ export default {
       if (this.currentIndex === index) {
         return this.isChipnet ? this.$store.getters['assets/getAllAssets'].chipnet_assets[0] : this.$store.getters['assets/getAllAssets'].asset[0]
       } else {
-        return this.isChipnet ? this.$store.getters['assets/getVault'][index].chipnet_assets[0] : this.$store.getters['assets/getVault'][index].asset[0]
+        const assetVault = this.$store.getters['assets/getVault']
+        if (!assetVault) return {}
+        return this.isChipnet ? assetVault[index].chipnet_assets[0] : assetVault[index].asset[0]
       }
     },
     openBasicInfoDialog () {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -42,7 +42,6 @@ export default function () {
       try {
         // Check if first mnemonic exists
         const currentWalletIndex = store.getters['global/getWalletIndex']
-        console.log('[vuex] currentWalletIndex:', currentWalletIndex)
         const mnemonic = await getMnemonic(currentWalletIndex)
 
         // if mnemonic does not exist but not first wallet,
@@ -60,12 +59,9 @@ export default function () {
           location.reload()
         }
 
-        console.log('[vuex] walletIndex:', walletIndex)
-
         if (mnemonic) {
           next()
         } else {
-          console.log('failed to find mnemonic from walletIndex')
           next('/accounts')
         }
       } catch (err) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -41,7 +41,8 @@ export default function () {
     if (to.path === '/') {
       try {
         // Check if first mnemonic exists
-        const currentWalletIndex = store.getters['global/getWalletIndex']        
+        const currentWalletIndex = store.getters['global/getWalletIndex']
+        console.log('[vuex] currentWalletIndex:', currentWalletIndex)
         const mnemonic = await getMnemonic(currentWalletIndex)
 
         // if mnemonic does not exist but not first wallet,
@@ -59,12 +60,16 @@ export default function () {
           location.reload()
         }
 
+        console.log('[vuex] walletIndex:', walletIndex)
+
         if (mnemonic) {
           next()
         } else {
+          console.log('failed to find mnemonic from walletIndex')
           next('/accounts')
         }
       } catch (err) {
+        console.error(err)
         next('/accounts')
       }
     } else {

--- a/src/store/global/mutations.js
+++ b/src/store/global/mutations.js
@@ -1,4 +1,4 @@
-import { deleteMnemonic } from './../../wallet'
+import { deleteMnemonic, deletePin, getMnemonic } from './../../wallet'
 import { deleteAuthToken as deleteP2PExchangeAuthToken } from 'src/exchange/auth'
 
 export function updateAppControl (state, data) {
@@ -84,9 +84,14 @@ export function updateCurrentWallet (state, index) {
   state.chipnet__wallets = chipnet
 }
 
-export function deleteWallet (state, index) {
+export async function deleteWallet (state, index) {
+
   // Mark wallet as deleted
   state.vault[index].deleted = true
+  
+  // Delete pin (awaited to avoid race condition with deleteMnemonic)
+  await deletePin(index)
+  
   // Delete the mnemonic seed phrase for this wallet
   deleteMnemonic(index)
 }

--- a/src/utils/wallet-hydration.js
+++ b/src/utils/wallet-hydration.js
@@ -1,0 +1,14 @@
+import localforage from "localforage";
+import useStore from 'src/store';
+
+const store = useStore()
+const persisted = await localforage.getItem('vuex')
+
+export async function hydrateWallet() {
+    const vault = persisted.global.vault
+    const walletIndex = persisted.global.walletIndex
+    
+    // hydrate walletIndex and vault
+    store.commit('global/updateWalletIndex', walletIndex)
+    store.commit('global/updateVault', vault)
+}

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -2,6 +2,7 @@ import { SlpWallet } from './slp'
 import { SmartBchWallet } from './sbch'
 import { BchWallet } from './bch'
 import { LibauthHDWallet } from './bch-libauth'
+import { sha256 } from 'js-sha256'
 import aes256 from 'aes256'
 
 import 'capacitor-secure-storage-plugin'
@@ -118,7 +119,6 @@ export async function getMnemonic (index = 0) {
     key = key + index
   }
 
-  console.log('[localstorage] getting mnemonic, key:', key)
   try {
     // For versions up to v0.9.1 that used to have aes256-encrypted mnemonic
     const secretKey = await SecureStoragePlugin.get({ key: 'sk' })
@@ -141,6 +141,12 @@ export async function deleteMnemonic (index) {
     key = key + index
   }
   await SecureStoragePlugin.remove({ key })
+}
+
+export async function deletePin (index) {
+  const mnemonic = await getMnemonic(index)
+  const pinKey = `pin-${sha256(mnemonic)}`
+  await SecureStoragePlugin.remove({ key: pinKey })
 }
 
 export { Address } from 'watchtower-cash-js';

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -117,6 +117,8 @@ export async function getMnemonic (index = 0) {
   if (index !== 0) {
     key = key + index
   }
+
+  console.log('[localstorage] getting mnemonic, key:', key)
   try {
     // For versions up to v0.9.1 that used to have aes256-encrypted mnemonic
     const secretKey = await SecureStoragePlugin.get({ key: 'sk' })
@@ -126,7 +128,9 @@ export async function getMnemonic (index = 0) {
     try {
       mnemonic = await SecureStoragePlugin.get({ key: key })
       mnemonic = mnemonic.value
-    } catch (err) {}
+    } catch (err) {
+      console.error(err)
+    }
   }
   return mnemonic
 }


### PR DESCRIPTION
## Description

- Fix: Resolved issue when switching wallets when the first wallet (index 0) is deleted.
  - Root cause: `App.vue` attempted to fetch `walletIndex` before Vuex was fully hydrated, resulting in a stale or incorrect index (0). If the wallet at index 0 was already deleted, calling `getMnemonic(index)` threw an error, which redirected the user to the "create/restore wallet" flow incorrectly.
  - Fix: Hydrate both `walletIndex` and the wallet vault from `IndexedDB` during boot, ensuring the state is ready before `App.vue` logic runs.
- Cleanup: Automatically deletes the PIN associated with a deleted wallet to free local storage and prevent stale PIN data from lingering.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dev UX improvement (ensures state is clean and predictable at launch)

## Test Notes
How Has This Been Tested?
- Deleted a wallet at index 0 and verified that the app no longer crashes or redirects incorrectly.
- Confirmed that the persisted PIN entry for the deleted wallet is removed from local storage.
- Checked that app boot now properly hydrates state before any wallet-related logic executes.

Steps to Reproduce Fixed Bug:
- Create multiple wallets.
- Delete the wallet at index 0 (the first wallet created, usually named `Personal wallet #1`).
- Restart app.
- Observe: No crash or misdirect to wallet creation screen.

## @mentions
@joemarct 