### PR TITLE
Fix cashback text displaying fiat equivalent as zero

### DIFF
--- a/src/components/send-page/SendPageForm.vue
+++ b/src/components/send-page/SendPageForm.vue
@@ -365,7 +365,7 @@ export default {
       const message = this.inputExtras.cashbackData.message
       const amountBch = this.inputExtras.cashbackData.cashback_amount
       const amountFiat = parseFiatCurrency(
-        convertToFiatAmount(this.inputExtras.cashbackData.cashback_amount),
+        convertToFiatAmount(amountBch, this.selectedAssetMarketPrice),
         this.currentSendPageCurrency()
       )
       const merchantName = this.inputExtras.cashbackData.merchant_name


### PR DESCRIPTION
## Description
This PR will fix the cashback text displaying fiat equivalent as zero.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update