### PR TITLE
Fix/wallet recovery

### DIFF
--- a/src/boot/vuex.js
+++ b/src/boot/vuex.js
@@ -1,6 +1,6 @@
 import { boot } from 'quasar/wrappers'
 import { migrateVuexStorage } from 'src/utils/indexed-db-rollback/rollback-vuex-storage'
-import { recoverWalletsFromStorage } from 'src/utils/indexed-db-rollback/wallet-recovery'
+import { populateMissingVaults, recoverWalletsFromStorage } from 'src/utils/indexed-db-rollback/wallet-recovery'
 import { sanitizeVault } from 'src/utils/indexed-db-rollback/wallet-vault'
 import { updatePreferences } from 'src/utils/indexed-db-rollback/update-preferences'
 import { resetWalletsAssetsList } from 'src/utils/indexed-db-rollback/reset-asset-list'
@@ -47,6 +47,7 @@ export default boot(async (obj) => {
     await recoverWalletsFromStorage()
     await resetWalletsAssetsList()
     updatePreferences()
+    populateMissingVaults()
     
   } catch (err) {
     console.error('Error initializing Vuex store:', err)

--- a/src/store/global/mutations.js
+++ b/src/store/global/mutations.js
@@ -86,9 +86,11 @@ export function updateWalletSnapshot (state, details) {
   chipnet = JSON.stringify(chipnet)
   chipnet = JSON.parse(chipnet)
 
+  if (!state.vault[details.index]) state.vault[details.index] = {}
   state.vault[details.index].wallet = wallet
   state.vault[details.index].chipnet = chipnet
   state.vault[details.index].name = details.name
+  state.vault[details.index].deleted = details.deleted
 }
 
 export function updateCurrentWallet (state, index) {

--- a/src/utils/indexed-db-rollback/wallet-recovery.js
+++ b/src/utils/indexed-db-rollback/wallet-recovery.js
@@ -203,24 +203,22 @@ async function recoverWallet(index, save=false) {
         }
     }
 
-    await wallet.sBCH.subscribeWallet().then(function () {
-        const walletTypeInfo = {
-            type: 'sbch',
-            derivationPath: wallet.sBCH.derivationPath,
-            walletHash: wallet.sBCH.walletHash,
-            lastAddress: wallet.sBCH._wallet ? wallet.sBCH._wallet.address : ''
-        }
-
-        if (save) store.commit('global/updateWallet', walletTypeInfo)
-
-        const walletSnapshot = {
-            walletHash: walletTypeInfo.walletHash,
-            derivationPath: walletTypeInfo.derivationPath,
-            lastAddress: walletTypeInfo.lastAddress
-        }
-
-        bchWalletsInfo['sbch'] = walletSnapshot
-    })
+    // sbch wallet info creation, skipped wallet subscription,
+    // will assume it's already subscribed if it's being recovered
+    await wallet.sBCH.getOrInitWallet();
+    const walletTypeInfo = {
+        type: 'sbch',
+        derivationPath: wallet.sBCH.derivationPath,
+        walletHash: wallet.sBCH.walletHash,
+        lastAddress: wallet.sBCH._wallet ? wallet.sBCH._wallet.address : ''
+    }
+    if (save) store.commit('global/updateWallet', walletTypeInfo)
+    const walletSnapshot = {
+        walletHash: walletTypeInfo.walletHash,
+        derivationPath: walletTypeInfo.derivationPath,
+        lastAddress: walletTypeInfo.lastAddress
+    }
+    bchWalletsInfo['sbch'] = walletSnapshot
 
     // const walletHashes = [
     //     wallet.BCH.walletHash,

--- a/src/utils/indexed-db-rollback/wallet-recovery.js
+++ b/src/utils/indexed-db-rollback/wallet-recovery.js
@@ -65,13 +65,14 @@ function emptyAssetsList() {
     return getAllAssets(initialAssetState())
 }
 
-export function populateMissingVaults() {
+export async function populateMissingVaults() {
     console.log('[Wallet Recovery] Populating null vaults')
     // this will autofill of earlier indices since indices might skip due to previously deleted wallets
     // skipped indices give a null element which breaks stuff in the app
     const walletVaults = Store.getters['global/getVault'];
     for (var i = 0; i < walletVaults.length; i++) {
-        if (walletVaults[i]) continue
+        const mnemonic = await getMnemonic(i)
+        if (walletVaults[i] && mnemonic) continue
         console.log(`[Wallet Recovery] Adding empty wallet snapshot for ${i}`)
         const emptyWalletSnapshot = getEmptyWalletSnapshot()
         Store.commit('global/updateWalletSnapshot', {

--- a/src/utils/indexed-db-rollback/wallet-recovery.js
+++ b/src/utils/indexed-db-rollback/wallet-recovery.js
@@ -78,8 +78,9 @@ export function resetAssetsList(index) {
 
     // this will autofill of earlier indices since indices might skip due to previously deleted wallets
     for(var i = vault.length; i <= index; i++) {
+        if (vault[i]) continue
         console.log(`[Wallet Recovery] Adding base assets list for ${i} in ${index}`)
-        store.commit('assets/updateVault', { index, asset: emptyAssetsList() })
+        store.commit('assets/updateVault', { index: i, asset: emptyAssetsList() })
     }
 
     store.commit('assets/updateVault', { index: index, asset: asset })
@@ -238,6 +239,7 @@ async function recoverWallet(index, save=false) {
 
     const vault = store.getters['global/getVault'];
     for (var i = vault.length; i <= index; i++) {
+        if (vault[i]) continue
         console.log(`[Wallet Recovery] Adding empty wallet snapshot for ${i} in ${index}`)
         const emptyWalletSnapshot = getEmptyWalletSnapshot()
         store.commit('global/updateWalletSnapshot', {

--- a/src/utils/indexed-db-rollback/wallet-recovery.js
+++ b/src/utils/indexed-db-rollback/wallet-recovery.js
@@ -85,7 +85,7 @@ async function recoverWallet(index, save=false) {
         const isChipnet = bchWallets.indexOf(bchWallet) === 1
 
         let walletSnapshot = {}
-        await bchWallet.getNewAddressSet(0).then(function (response) {
+        await bchWallet.getAddressSetAt(0).then(function (response) {
             const addresses = response?.addresses || null
             const walletTypeInfo = {
                 isChipnet,
@@ -137,7 +137,7 @@ async function recoverWallet(index, save=false) {
         const isChipnet = slpWallets.indexOf(slpWallet) === 1
 
         let walletSnapshot = {}
-        await slpWallet.getNewAddressSet(0).then(function (addresses) {
+        await slpWallet.getAddressSetAt(0).then(function (addresses) {
             const walletTypeInfo = {
                 isChipnet,
                 type: 'slp',

--- a/src/utils/indexed-db-rollback/wallet-recovery.js
+++ b/src/utils/indexed-db-rollback/wallet-recovery.js
@@ -304,7 +304,8 @@ export async function recoverWalletsFromStorage() {
     const reloadCurrentActiveWallet = !currentActiveWallet.xPubKey || currentActiveWallet.xPubKey === ''
     console.log('[Wallet Recovery] reloadCurrentActiveWallet:', reloadCurrentActiveWallet)
 
-    const hasRecoverableWallets = vault.length < walletIndices.length || reloadCurrentActiveWallet
+    const lastWalletIndex = Math.max(...walletIndices)
+    const hasRecoverableWallets = vault.length < lastWalletIndex+1 || reloadCurrentActiveWallet
     console.log('[Wallet Recovery] hasRecoverableWallets:', hasRecoverableWallets);
 
     if (!hasRecoverableWallets) {

--- a/src/utils/indexed-db-rollback/wallet-recovery.js
+++ b/src/utils/indexed-db-rollback/wallet-recovery.js
@@ -65,6 +65,33 @@ function emptyAssetsList() {
     return getAllAssets(initialAssetState())
 }
 
+export function populateMissingVaults() {
+    console.log('[Wallet Recovery] Populating null vaults')
+    // this will autofill of earlier indices since indices might skip due to previously deleted wallets
+    // skipped indices give a null element which breaks stuff in the app
+    const walletVaults = Store.getters['global/getVault'];
+    for (var i = 0; i < walletVaults.length; i++) {
+        if (walletVaults[i]) continue
+        console.log(`[Wallet Recovery] Adding empty wallet snapshot for ${i}`)
+        const emptyWalletSnapshot = getEmptyWalletSnapshot()
+        Store.commit('global/updateWalletSnapshot', {
+            index: i,
+            name: emptyWalletSnapshot.name,
+            walletSnapshot: emptyWalletSnapshot.wallet,
+            chipnetSnapshot: emptyWalletSnapshot.chipnet,
+            deleted: true,
+        })
+    }
+
+    const assetVaults = Store.getters['assets/getVault'];
+    for(var i = 0; i < assetVaults.length; i++) {
+        if (assetVaults[i]) continue
+        console.log(`[Wallet Recovery] Adding base assets list for ${i}`)
+        Store.commit('assets/updateVault', { index: i, asset: emptyAssetsList() })
+    }
+}
+
+
 export function resetAssetsList(index) {
     const store = Store;
     const vault = store.getters['assets/getVault'];


### PR DESCRIPTION
## Description
Fixed indexing mismatch for wallet infos in vault during indexed db rollback's wallet recovery process when app has previously deleted wallets.




## Screenshots (if applicable):
n/a


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Can be tested with browser local dev or a debug build by switching between versions to simulate vuex's indexeddb migration and rollback. (When switching versions in browser, close tab first and wait for server to recompile before opening tab again.)
1. Start empty app in version `0.22.6`
2. Add 3 wallets
3. Deleted 3rd wallet. Should have 2 wallets left in app
4. Add 2 more wallets. Should have 4 wallets left in app
5. Switch to version `0.22.7`.
    - There will be error on load (black screen), check on localstorage if `vuex` key disappeared.
6. Switch to version `0.22.9`.
    - Wait for around 1 min when page loads to allow wallet recovery to finish. 
    - When opening multi-wallet dropdown, there may be an error. And only 1-2 wallets visible when there should be 4
8. Switch to this branch.
    - The 4 wallets should be multi wallet dropdown
