### PR TITLE
Fix/wallet recovery

### DIFF
--- a/src/utils/indexed-db-rollback/wallet-recovery.js
+++ b/src/utils/indexed-db-rollback/wallet-recovery.js
@@ -112,7 +112,9 @@ export function resetAssetsList(index) {
     }
 
     store.commit('assets/updateVault', { index: index, asset: asset })
-    store.commit('assets/updatedCurrentAssets', index)
+    if (index === store.getters['global/getWalletIndex']) {
+        store.commit('assets/updatedCurrentAssets', index)
+    }
 }
 
 async function recoverWallet(index, save=false) {
@@ -300,12 +302,8 @@ export async function recoverWalletsFromStorage() {
         walletIndices.splice(0, walletIndices.length - 30)
     }
 
-    const currentActiveWallet = Store.getters['global/getWallet']('bch')
-    const reloadCurrentActiveWallet = !currentActiveWallet.xPubKey || currentActiveWallet.xPubKey === ''
-    console.log('[Wallet Recovery] reloadCurrentActiveWallet:', reloadCurrentActiveWallet)
-
     const lastWalletIndex = Math.max(...walletIndices)
-    const hasRecoverableWallets = vault.length < lastWalletIndex+1 || reloadCurrentActiveWallet
+    const hasRecoverableWallets = vault.length < lastWalletIndex+1 && walletIndices.length > 0
     console.log('[Wallet Recovery] hasRecoverableWallets:', hasRecoverableWallets);
 
     if (!hasRecoverableWallets) {
@@ -316,7 +314,7 @@ export async function recoverWalletsFromStorage() {
 
     Store.commit('global/setWalletsRecovered', false)
 
-    if (isVaultEmpty || reloadCurrentActiveWallet) {
+    if (isVaultEmpty || hasRecoverableWallets) {
         // If the vault was previously empty await the first wallet only
         const firstIndex = walletIndices[0]
         await recoverWallet(firstIndex, true)

--- a/src/utils/indexed-db-rollback/wallet-vault.js
+++ b/src/utils/indexed-db-rollback/wallet-vault.js
@@ -15,14 +15,14 @@ export function sanitizeVault() {
 
                 // Check for critical fields: e.g., valid non-empty xPubKey
                 const hasValidXPubKey = typeof entry?.wallet?.bch?.xPubKey === 'string' && entry?.wallet?.bch?.xPubKey.trim() !== '';
-                return hasValidXPubKey;
+                return hasValidXPubKey || entry?.deleted;
             }
         );
         
         console.log('[Sanitize Vault] sanitizedVault:', sanitizedVault)
         if (sanitizedVault.length !== vault.length) {
             Store.commit('global/clearVault')
-            Store.commit('global/updateVault', sanitizedVault);
+            sanitizedVault.forEach(vault => Store.commit('global/updateVault', vault))
             console.log('[Sanitize Vault] Invalid entries removed from vault');
         }
     }


### PR DESCRIPTION
## Description
- Force rerun wallet recovery to fix inconsistencies on wallet mnemonic indexing & vault data.
- Fix wallet recovery bug on apps with deleted wallet on index 0 causing inconsistent wallet data for wallet at index 0
- Fix bug wallet recovery always running due to sanitize vaults removing records of deleted wallets from recovery
- Active wallet index copying assets list of last wallet from vault

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes
- Tested by starting moving between versions to simulate indexeddb migration and rollback. Moved version in this sequence:`0.22.6`  -> `0.22.7` -> `0.22.9` -> `0.22.10` -> this branch. 
  - When moving between branches, must open to main page first to run migrations & rollback processes
  - While in `0.22.6` create multiple wallets. Also tested where 1 wallet is deleted, 1 test case for deleting wallet at index 0 and another for deleting wallet at index 1+.
- For each wallet, check addresses, balances, tokens list if consistent with the stored mnemonic in localstorage