### PR TITLE
Fix/exchange

### DIFF
--- a/src/components/ramp/fiat/AdListings.vue
+++ b/src/components/ramp/fiat/AdListings.vue
@@ -80,8 +80,8 @@
                               {{
                                 $t(
                                   'CompletionPercentage',
-                                  { percentage: Number(listing.completion_rate.toFixed(2)) },
-                                  `${ Number(listing.completion_rate.toFixed(2)) }% completion`
+                                  { percentage: Number(listing.completion_rate?.toFixed(2)) },
+                                  `${ Number(listing.completion_rate?.toFixed(2)) }% completion`
                                 )
                               }}
                             </span>
@@ -148,7 +148,9 @@
                         </div>
                       </div>
                       <div class="q-gutter-sm q-pt-xs">
-                        <q-badge v-for="(method, index) in listing.payment_methods" :key="index" rounded outline :color="darkMode ? 'white': 'black'" :label="method" />
+                        <q-badge v-for="(method, index) in listing.payment_methods" :key="index" rounded outline :color="darkMode ? 'white': 'black'">
+                          {{ typeof(method) === 'object' ? method?.payment_type?.short_name : method }}
+                        </q-badge>
                       </div>
                     </div>
                   </q-item-section>
@@ -335,7 +337,7 @@ export default {
       this.visibilityLoading[ad.id] = true
       await backend.put(`ramp-p2p/ad/${ad.id}/`, { is_public: !ad.is_public }, { authorize: true })
         .then(response => {
-          this.listings[index] = response.data
+          this.listings[index].is_public = response.data.is_public
         })
         .catch(error => {
           this.handleRequestError(error)

--- a/src/components/ramp/fiat/PaymentConfirmation.vue
+++ b/src/components/ramp/fiat/PaymentConfirmation.vue
@@ -192,7 +192,7 @@
         </div>
       </div>
       <!-- Appeal Button -->
-      <div class="row justify-center" v-if="countDown !== null">
+      <div class="row justify-center" v-if="showAppealBtn">
         <q-btn
           v-if="!sendingBch"
           :loading="loadAppealButton"
@@ -296,6 +296,19 @@ export default {
     }
   },
   computed: {
+    showAppealBtn () {
+      let showBtn = false
+      const status = this.order?.status.value      
+      const userType = this.data?.type
+      if (userType === 'seller') {
+        showBtn = status === 'ESCRW'
+      }
+
+      if (userType === 'buyer') {
+        showBtn = status === 'PD_PN'
+      }
+      return showBtn && this.countDown !== null
+    },
     maxFileSize () {
       return 5 * 1024 * 1024
     },

--- a/src/pages/apps/exchange/peer_to_peer/ad-form.vue
+++ b/src/pages/apps/exchange/peer_to_peer/ad-form.vue
@@ -1,9 +1,10 @@
 <template>
-  <HeaderNav :title="`P2P Exchange`" :backnavpath="previousRoute"/>
-  <div v-if="step === 1"
-    class="text-bow"
-    :class="getDarkModeClass(darkMode)">
-    <div v-if="step === 1">
+  <div>
+    <HeaderNav :title="`P2P Exchange`" :backnavpath="previousRoute"/>
+    <div v-if="currentStep === 1"
+      class="text-bow"
+      :class="getDarkModeClass(darkMode)">
+    <div v-if="currentStep === 1">
       <div
         class="text-h5 q-mx-lg q-py-xs text-center text-weight-bold lg-font-size"
         :class="transactionType === 'BUY' ? 'buy-color' : 'sell-color'"
@@ -245,28 +246,28 @@
         </q-scroll-area>
       </div>
     </div>
-    <div v-if="step > 3">
+    <div v-if="currentStep > 3">
       <div class="row justify-center q-py-lg" style="margin-top: 50px">
         <ProgressLoader :color="isNotDefaultTheme(theme) ? theme : 'pink'"/>
       </div>
     </div>
   </div>
-  <div v-if="step === 2">
+  <div v-if="currentStep === 2">
     <AddPaymentMethods
       :type="'Ads'"
       :confirm-label="$t('Next')"
       :currency="adData.fiatCurrency.symbol"
       :currentPaymentMethods="adData.paymentMethods"
       @submit="nextStep"
-      @back="step--"
+      @back="currentStep--"
     />
   </div>
-  <div v-if="step === 3">
+  <div v-if="currentStep === 3">
     <DisplayConfirmation
       :post-data="confirmationData"
       :ptl="appealCooldown"
       :transaction-type="transactionType"
-      v-on:back="step--"
+      v-on:back="currentStep--"
       @submit="nextStep"
     />
   </div>
@@ -277,6 +278,7 @@
       :text=text
       v-on:back="openDialog = false"
     />
+  </div>
   </div>
 </template>
 <script>
@@ -313,6 +315,20 @@ export default {
     HeaderNav
   },
   emits: ['back', 'submit', 'updatePageName'],
+  props: {
+    type: {
+      type: String,
+      default: null
+    },
+    step: {
+      type: [String, Number],
+      default: 1
+    },
+    ad_id: {
+      type: String,
+      default: null
+    }
+  },
   data () {
     return {
       darkMode: this.$store.getters['darkmode/getStatus'],
@@ -323,7 +339,7 @@ export default {
       websocket: null,
       marketPrice: null,
       priceValue: null,
-      step: 1,
+      currentStep: 1,
       priceAmount: 0,
       floatingPrice: 100, // default: 100%
       appealCooldown: {
@@ -442,7 +458,7 @@ export default {
         this.adData.tradeAmount = amount
       }
     },
-    step (value) {
+    currentStep (value) {
       this.$emit('updatePageName', `ad-form-${value}`)
     },
     marketPrice (value) {
@@ -512,8 +528,8 @@ export default {
       return data
     }
   },
-  async mounted () {
-    this.step = Number(this.$route.query?.step) || 1
+    async mounted () {
+    this.currentStep = Number(this.step) || 1
     this.loadFormData()
   },
   beforeUnmount () {
@@ -712,7 +728,7 @@ export default {
       try {
         const response = await backend.get('/ramp-p2p/ad/currency/', { params: { trade_type: vm.transactionType }, authorize: true })
         vm.fiatCurrencies = response.data
-        const selectedCurrencyUnused = vm.adsState === 'create' && !vm.fiatCurrencies.map(e => e.id)?.includes(vm.selectedCurrency.id)
+        const selectedCurrencyUnused = vm.adsState === 'create' && !vm.fiatCurrencies.map(e => e.symbol)?.includes(vm.selectedCurrency.symbol)
         if (!vm.selectedCurrency || selectedCurrencyUnused) {
           vm.selectedCurrency = vm.fiatCurrencies[0]
           vm.adData.fiatCurrency = vm.selectedCurrency
@@ -751,7 +767,7 @@ export default {
       }
     },
     async nextStep (data) {
-      const currentStep = this.step
+      const currentStep = this.currentStep
       if (currentStep === 2) {
         this.adData.paymentMethods = data
       }
@@ -761,8 +777,8 @@ export default {
         // await this.$router.push({ name: 'p2p-ads' })
       }
       if (currentStep < 3) {
-        this.step++
-        await this.$router.replace({ query: { ...this.$route.query, step: this.step } })
+        this.currentStep++
+        await this.$router.replace({ query: { ...this.$route.query, step: this.currentStep } })
       }
     },
     async onSubmit () {
@@ -834,7 +850,6 @@ export default {
       } else {
         payload.trade_amount_sats = bchToSatoshi(data.tradeAmount)
       }
-      console.log('payload:', payload)
       return payload
     },
     updatePriceValue (priceType) {

--- a/src/pages/apps/exchange/peer_to_peer/index.vue
+++ b/src/pages/apps/exchange/peer_to_peer/index.vue
@@ -1,8 +1,10 @@
 <template>
-  <router-view :key="$route.path"></router-view>
-  <NoticeBoardDialog v-if="showNoticeBoard" :type="noticeBoardType" :message="noticeBoardMessage" @hide="showNoticeBoard=false"/>
-  <FooterMenu v-if="showFooterMenu" :tab="currentPage" :data="footerData"/>
-  <RampLogin v-if="showLogin" :force-login="forceLogin" @logged-in="showLogin = false; forceLogin = false"/>
+  <div>
+    <router-view :key="$route.path"></router-view>
+    <NoticeBoardDialog v-if="showNoticeBoard" :type="noticeBoardType" :message="noticeBoardMessage" @hide="showNoticeBoard=false"/>
+    <FooterMenu v-if="showFooterMenu" :tab="currentPage" :data="footerData"/>
+    <RampLogin v-if="showLogin" :force-login="forceLogin" @logged-in="showLogin = false; forceLogin = false"/>
+  </div>
 </template>
 <script>
 import NoticeBoardDialog from 'src/components/ramp/fiat/dialogs/NoticeBoardDialog.vue'

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -132,13 +132,11 @@ const routes = [
       {
         path: 'exchange/',
         name: 'exchange',
-        props: route => route.query,
         component: () => import('src/pages/apps/exchange/index.vue'),
         children: [
           {
             path: 'peer-to-peer/',
             name: 'exchange-p2p',
-            props: route => route.query,
             component: () => import('src/pages/apps/exchange/peer_to_peer/index.vue'),
             children: [
               {


### PR DESCRIPTION
## Description

This PR includes several UI and validation improvements for the ad creation and listing flow:

Ad Creation and Preferences
- Fix: Default fiat currency is now set based on the user's preferred currency when creating or reloading ads.
- Chore: Cleaned up related component warnings for smoother development experience.

Input Validation
- Fix: Prevented creation of ads with trade limits lower than 0.00001 to avoid invalid or unusable listings.

Ad Listings and UI
- Fix: Resolved an error when toggling ad visibility.
- Fix: Ensured missing payment methods are properly displayed in the ad listings page.

Payment Confirmation Behavior
- Fix: Appeal button is now hidden from the BCH buyer's side until they confirm payment. Previously, buyers could initiate an appeal to release without confirming payment, which has now been prevented to ensure proper flow.

## Screenshots (if applicable):
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes
How Has This Been Tested?

- Confirm default fiat currency reflects user preference in ad forms.
- Ensure ad creation is blocked for limits below 0.00001.
- Check toggle ad visibility and payment methods display as expected in Ad Listings.
- Verify that BCH buyers cannot see the appeal button before confirming payment.

## @mentions
@joemarct 
