### PR TITLE
Improvement/deep link

### DIFF
--- a/src/pages/qr/qr-reader.vue
+++ b/src/pages/qr/qr-reader.vue
@@ -10,7 +10,7 @@
     </div>
     <template v-else>
       <qrcode-stream
-        v-if="!isMobile"
+        v-if="!isMobile && !decode"
         :camera="frontCamera ? 'front': 'auto'"
         :paused="paused"
         @detect="onQRDecode"
@@ -91,6 +91,10 @@ export default {
     // eslint-disable-next-line vue/no-unused-components
     LoadingWalletDialog,
     QRUploader
+  },
+
+  props: {
+    decode: String,
   },
 
   data () {
@@ -430,10 +434,11 @@ export default {
   mounted () {
     const vm = this
 
-    if (vm.isMobile) {
+    if (vm.decode) {
+      vm.onQRDecode([{ rawValue: vm.decode }])
+    } else if (vm.isMobile) {
       vm.prepareScanner()
     }
-    window.scan = val => vm.onQRDecode([{ rawValue: val }])
 
     vm.clWidth = `${document.body.clientWidth}px`
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -76,9 +76,6 @@ export default function () {
     const url = new URL(event.url)
     console.log('App URL open', { url })
 
-    let baseURL = store.getters['global/isChipnet'] ? process.env.CHIPNET_WATCHTOWER_BASE_URL : process.env.MAINNET_WATCHTOWER_BASE_URL || ''
-    baseURL = baseURL.replace('https://', '').replace('http://', '').replace('/api', '')
-
     if (/\/payment-request\/?$/.test(url.pathname) || /\/apps\/connecta\/?$/.test(url.pathname)) {
       const query = {}
       if (url.searchParams.has('d')) query.paymentRequestData = url.searchParams.get('d')
@@ -98,7 +95,13 @@ export default function () {
         name: 'app-sweep',
         query: { w: extractWifFromUrl(String(url)) }
       })
-    } else if (['ethereum:', 'bitcoincash:', 'paytaca:'].indexOf(url.protocol) >= 0) {
+    } else if (url.protocol === 'bitcoincash:') {
+      // will need to refactor to have similar behavior as in qr scanner page
+      Router.push({
+        name: 'qr-reader',
+        query: { decode: url.toString() },
+      })
+    } else if (['ethereum:', 'paytaca:'].indexOf(url.protocol) >= 0) {
       const query = { assetId: 'bch', paymentUrl: String(url) }
       try {
         const parsedPaymentUri = parsePaymentUri(


### PR DESCRIPTION
## Description
- Update deep link router for bip021 to use qr reader decoder.
- Fixes bug where opening payment urls through deep links are not handling cashtoken parameters. Needed for cashtoken tipping in spicebot.

Fixes # (issue)

## Screenshots (if applicable):
n/a


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Must be tested on mobile build. In the device, click a bip021 link with cashtoken parameters. Example: 
```
bitcoincash:zqrhqr3v463pfqe9dejtvaagr922ja5mecnykkpadn?t&c=b38a33f750f84c5c169a6f23cb873e6e79605021585d4f3408789689ed87f366&f=23
```
## @mentions
Mention the person or team responsible for reviewing the proposed changes.
