### PR TITLE
Hotfix/ft decimals

### DIFF
--- a/src/pages/apps/multisig/wallet/asset.vue
+++ b/src/pages/apps/multisig/wallet/asset.vue
@@ -32,9 +32,17 @@
                       </div>
                       <div class="col-xs-12 text-center">
                         <div class="text-white">{{ $t('Balance') }}</div>
-                        <div class="items-center justify-center q-gutter-x-sm">
-                          <span style="font-size: 2em">{{ balance !== undefined ? balance : "..." }}</span>
+                        <div v-if="route.query.asset === 'bch'" class="items-center justify-center q-gutter-x-sm">
+                          <span style="font-size: 2em">
+                            {{ balance !== undefined ? balance : "..." }}
+                          </span>
                           <div>{{ assetPrice? `=${assetPrice}` : '' }}</div>
+                        </div>
+                        <div v-else class="items-center justify-center q-gutter-x-sm">
+                          <span style="font-size: 2em">
+
+                            {{ Big(balance ?? 0).div(`1e${assetTokenIdentity?.token?.decimals || 0}`) }}
+                          </span>
                         </div>
                       </div>
                     </div>
@@ -96,6 +104,25 @@
                  <q-item-label class="flex flex-wrap items-center">
                    <span>
                     {{ shortenString(route.query.asset, 20)}}<CopyButton :text="route.query.asset"/>
+                   </span>
+                 </q-item-label>
+                </q-item-section>
+              </q-item>
+              <q-item v-if="route.query.asset !== 'bch'" dense>
+                <q-item-section>
+                  <q-item-label>
+                    <div class="flex items-center">
+                      <q-icon name="mdi-numeric"></q-icon>
+                      <span class="q-ml-xs">
+                        {{ $t('Decimals' ) }}
+                      </span>
+                    </div>
+                  </q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                 <q-item-label class="flex flex-wrap items-center">
+                   <span>
+                    {{ assetTokenIdentity?.token?.decimals || '?'}}
                    </span>
                  </q-item-label>
                 </q-item-section>
@@ -192,6 +219,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuasar } from 'quasar'
 import ago from 's-ago'
+import Big from 'big.js'
 import { CashAddressNetworkPrefix } from 'bitauth-libauth-v3'
 import HeaderNav from 'components/header-nav'
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'

--- a/src/pages/apps/multisig/wallet/transaction/send.vue
+++ b/src/pages/apps/multisig/wallet/transaction/send.vue
@@ -35,9 +35,14 @@
                             size="sm"
                             :color="assetHeaderIcon === 'token'? 'grey': '' "
                           />
-                          <span style="font-size: 2em">{{ (availableBalance ?? 0 ) > 0 ? availableBalance?.toFixed(8): '0'}}</span>
+                          <span v-if="route.query.asset === 'bch'" style="font-size: 2em">
+                            {{ (availableBalance ?? 0 ) > 0 ? availableBalance?.toFixed(8): '0'}}
+                          </span>
+                          <span v-else style="font-size: 2em">
+                            {{ (availableBalance ?? 0 ) > 0 ? availableBalance?.toFixed(assetTokenIdentity?.token?.decimals || 0): '0'}}
+                          </span>
                         </div>
-                        <div>{{ (availableBalance ?? 0 ) > 0 && assetPrice ? `=${assetPrice}` : '' }}</div>
+                        <div v-if="route.query.asset === 'bch'" >{{ (availableBalance ?? 0 ) > 0 && assetPrice ? `=${assetPrice}` : '' }}</div>
                       </div>
                       <div v-if="walletWcSessionHistory?.length > 0 && walletWcAccountUtxos?.length > 0" class="col-xs-12">
                         <div class="text-center">
@@ -233,7 +238,8 @@ const walletWcReserveFunds = computed(() => {
     if (!asset || asset === 'bch') {
       return defaultAddressUtxos.filter(u => !u.token).reduce((b, u) => b + (u.satoshis || 0), 0) / 1e8
     }
-    return defaultAddressUtxos.filter(u => u.token && u.token?.category === asset).reduce((b, u) => b + (u.token?.amount || 0), 0)
+    const tokenReserveFunds = defaultAddressUtxos.filter(u => u.token && u.token?.category === asset).reduce((b, u) => b + (u.token?.amount || 0), 0)
+    return Big(tokenReserveFunds).div(`1e${assetTokenIdentity.value?.token?.decimals || 0}`).toString()
   }
   return undefined
 })
@@ -303,7 +309,16 @@ const DUST_LIMIT = 546
 const amountRules = computed(() => {
   let rules = [
     v => ( v?.length === 0 || /^(\d+)?\.?(\d+)?$/.test(v)) || $t('InvalidValue'),
-    v => !v || Number(v) < availableBalance.value || $t('ValueExceedsBalance'),
+    v => {
+      if (!v) return true
+      if (route.query.asset !== 'bch') {
+        return (Number(v) <= availableBalance.value) || $t('ValueExceedsBalance') 
+      }
+      if (route.query.asset === 'bch') {
+        return (Number(v) < availableBalance.value) || $t('ValueExceedsBalance') 
+      }
+      return true
+    },
     v => {
       if (v === '' || v === undefined) return true
       const sats = Math.round(v * 1e8);
@@ -424,6 +439,13 @@ const createProposal = async () => {
         creator = generateCosignerAuthPublicKeyFromXpub({ xpub: signer.xpub })
       }
     }
+
+    if (route.query.asset !== 'bch' && Number(assetTokenIdentity.value?.token?.decimals || 0) > 0) {
+      recipients.value.forEach((r) => {
+        r.decimals =  Number(assetTokenIdentity.value.token.decimals)
+      })
+    }
+
     const proposal = await wallet.value.createProposal({
       creator: creator,
       origin: 'paytaca-wallet',
@@ -519,14 +541,20 @@ onBeforeMount(async () => {
 
 onMounted(async () => {
   balance.value = await wallet.value.getWalletBalance(route.query.asset)
-  
   balanceConvertionRates.value = 
       await wallet.value.convertBalanceToCurrencies(
         route.query.asset,
         balance.value,
         [$store.getters['market/selectedCurrency'].symbol]
       )
+  
   assetTokenIdentity.value = await getAssetTokenIdentity(route.query.asset)
+  if (route.query.asset !== 'bch' && 
+    assetTokenIdentity.value?.token?.decimals && 
+    Number(assetTokenIdentity.value?.token?.decimals) > 0) {
+    balance.value = Big(balance.value).div(`1e${assetTokenIdentity.value.token.decimals}`).toString()
+  }
+
   await wallet.value.subscribeWalletAddressIndex(wallet.value.getLastUsedChangeAddressIndex(network) + 1, 'change')
   purpose.value = `${$t('Send')} ${assetHeaderName.value}`
 })

--- a/src/pages/apps/multisig/wallet/view.vue
+++ b/src/pages/apps/multisig/wallet/view.vue
@@ -238,7 +238,7 @@
                         </div>
                     </q-item-section>
                     <q-item-section side>
-                      {{ balances?.[asset] ? Big(balances[asset]).div(`1e${balances?.[asset]?.decimals || 0}`) : '...' }}
+                      {{ balances?.[asset] ? Big(balances[asset]).div(`1e${tokenIdentities[asset]?.token?.decimals || 0}`) : '...' }}
                     </q-item-section>
                   </q-item>
                 </template>
@@ -688,6 +688,7 @@ const discoverTokenIdentities = async (balances) => {
       identity: await getAssetTokenIdentity(asset)
     }))
   )
+
   return Object.fromEntries(results.map(r => [r.asset, r.identity]))
 }
 


### PR DESCRIPTION
## Description

- Correctly displays token balance with decimals
- Decimals attached to each recipient when creating proposal for tokens
- Correctly convert walletWcReserveFund raw token amount to decimal representation
- Update amount validation

Fixes # (issue)
Incorrect handling of Fungible tokens with decimals

## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Created  proposal sending BCH asset
Created proposal sending Fungible Token asset (with decimals)
Both transaction successful, correct fungible token amount received by recipient 

## @mentions
@joemarct 
