### PR TITLE
fix(send): allow sending NFTs when commitment is empty

### DIFF
--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -1898,7 +1898,8 @@ export default {
             const tokenAmount = (vm.commitment && vm.capability) ? 0 : sendData.amount
             token = {
               tokenId: tokenId,
-              commitment: vm.commitment || undefined,
+              // empty-string is valid for an NFT commitment so should not be collapsed to undefined
+              commitment: vm.commitment ?? undefined,
               capability: vm.capability || undefined,
               txid: vm.$route.query.txid,
               vout: vm.$route.query.vout


### PR DESCRIPTION
## Description
  Sending a ParyonUSD LoanKey (minting-capability NFT with empty commitment) from the latest mobile wallet failed with "can not send 0 fungible tokens".

### Bug

  Diagnosed with Claude: `processBchData` in `src/pages/transaction/send.vue` stripped empty-string commitments via `vm.commitment || undefined`, so watchtower-cash-js received a token payload with `commitment: undefined` and rejected it via the `totalTokenSendAmount === 0n && token.commitment ===
  undefined` guard in `src/bch/index.ts`. 

### Fix

Switched to `?? undefined` so empty commitments survive; also keys `tokenAmount = 0` off `vm.isNFT` so NFTs never fall into the fungible branch. Added an inline comment so future reviewers don't "normalize" the `??` back to `||`.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Test Notes
  Send a ParyonUSD LoanKey (or other minting NFT, empty commitment) from collectibles → confirm send succeeds.