### PR TITLE
fix(wizardconnect): hydrate source-output Uint8Array fields per hdwalletv1 spec

### DIFF
--- a/src/wallet/wizardconnect/service.js
+++ b/src/wallet/wizardconnect/service.js
@@ -1,5 +1,6 @@
 // import { WalletConnectionManager } from '@wizardconnect/wallet'
 import { mnemonicToSeedSync } from 'bip39'
+import { toUint8Array, toBigInt } from '@wizardconnect/core'
 import {
   deriveHdPrivateNodeFromSeed,
   deriveHdPrivateNodeChild,
@@ -13,7 +14,7 @@ import {
   decodeTransaction,
 } from 'bitauth-libauth-v3'
 import { getMnemonic } from 'src/wallet/index'
-import { parseExtendedJson, signBchTransaction } from 'src/wallet/bch-sign'
+import { signBchTransaction } from 'src/wallet/bch-sign'
 
 const seedCache = new Map()
 const relayKeyCache = new Map()
@@ -177,6 +178,49 @@ export async function sendSignError(connectionId, sequence, errorMessage) {
 }
 
 /**
+ * Hydrate a source output from the wire per the hdwalletv1 spec.
+ *
+ * Uint8Array fields may arrive as plain hex strings (emitted by the reference
+ * sourceOutputToRelay serializer) or as extended JSON (`<Uint8Array: 0x...>`).
+ * BigInts arrive as extended JSON (`<bigint: Xn>`). The toUint8Array /
+ * toBigInt helpers from @wizardconnect/core transparently handle every
+ * documented format, which is the deserialization path the spec prescribes.
+ *
+ * Zero-length placeholder unlockingBytecode is dropped — downstream compiler
+ * logic treats an absent property as a placeholder.
+ */
+function hydrateSourceOutput(so) {
+  const hasUnlocking =
+    so.unlockingBytecode !== undefined &&
+    so.unlockingBytecode !== '' &&
+    so.unlockingBytecode?.length !== 0
+  return {
+    outpointTransactionHash: toUint8Array(so.outpointTransactionHash),
+    outpointIndex: so.outpointIndex,
+    sequenceNumber: so.sequenceNumber,
+    valueSatoshis: toBigInt(so.valueSatoshis),
+    lockingBytecode: toUint8Array(so.lockingBytecode),
+    ...(hasUnlocking && { unlockingBytecode: toUint8Array(so.unlockingBytecode) }),
+    ...(so.token && { token: hydrateToken(so.token) }),
+  }
+}
+
+function hydrateToken(token) {
+  return {
+    category: toUint8Array(token.category),
+    amount: toBigInt(token.amount),
+    ...(token.nft && { nft: hydrateNft(token.nft) }),
+  }
+}
+
+function hydrateNft(nft) {
+  return {
+    ...(nft.capability !== undefined && { capability: nft.capability }),
+    ...(nft.commitment !== undefined && { commitment: toUint8Array(nft.commitment) }),
+  }
+}
+
+/**
  * Sign a transaction request from a dApp.
  * Uses inputPaths from the request to derive exactly the keys needed for each input.
  */
@@ -186,18 +230,7 @@ export async function signRequest(request) {
   const transaction = decodeTransaction(hexToBin(txHex))
   if (typeof transaction === 'string') throw new Error('Failed to decode transaction: ' + transaction)
 
-  // sourceOutputs may contain extended JSON strings like "<Uint8Array: 0x...>" and "<bigint: ...>"
-  // Always re-stringify then parse to ensure proper deserialization of binary/bigint values
-  const rawSourceOutputs = parseExtendedJson(JSON.stringify(request.transaction.sourceOutputs))
-
-  // Strip only zero-length placeholder unlockingBytecode; preserve CashScript template data
-  const sourceOutputs = rawSourceOutputs.map(so => {
-    if (so.unlockingBytecode && so.unlockingBytecode.length === 0) {
-      const { unlockingBytecode, ...rest } = so
-      return rest
-    }
-    return so
-  })
+  const sourceOutputs = request.transaction.sourceOutputs.map(hydrateSourceOutput)
 
   const prefix = getPrefix()
 


### PR DESCRIPTION
## Problem

\`signRequest\` hydrates \`sourceOutputs\` via \`parseExtendedJson\`, which only
matches the \`<Uint8Array: 0x...>\` / \`<bigint: ...n>\` markers.

The hdwalletv1 spec accepts **two** wire formats for \`Uint8Array\` — plain
hex and the extended marker — and the library's reference serializer
(\`@wizardconnect/core/hdwalletv1-serialize\` → \`sourceOutputToRelay\`) emits
plain hex. Spec guidance is for wallets to use \`toUint8Array\` / \`toBigInt\`
per field, which handle both.

Today any dapp using the reference serializer crashes Paytaca when signing a
tx that spends a token UTXO (e.g. PUSD repay, CashToken send) with:

    token.category.slice(...).reverse is not a function

## Fix

Replace the whole-object \`parseExtendedJson\` with a per-field hydrator
using \`toUint8Array\` / \`toBigInt\` from \`@wizardconnect/core\`.