### PR TITLE
fix(wizardconnect): lazy-init manager on first use

### DIFF
--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -137,7 +137,7 @@ export async function pair ({ commit, state, rootGetters }, { uri }) {
   if (!uri) throw new Error('URI is required')
   const normalizedUri = uri.trim()
   const walletHash = rootGetters['global/getWallet']?.('bch')?.walletHash || null
-  const connectionId = wizardConnectService.connect(normalizedUri)
+  const connectionId = await wizardConnectService.connect(normalizedUri)
   addSavedUri(walletHash, normalizedUri)
   return connectionId
 }

--- a/src/wallet/wizardconnect/service.js
+++ b/src/wallet/wizardconnect/service.js
@@ -149,9 +149,9 @@ export function reset() {
   _hdNodes = null
 }
 
-export function connect(uri) {
-  if (!_manager) throw new Error('Manager not initialized')
-  return _manager.connect(uri)
+export async function connect(uri) {
+  const manager = await getManager()
+  return manager.connect(uri)
 }
 
 export function disconnect(connectionId) {
@@ -168,13 +168,13 @@ export function disconnectAll() {
 }
 
 export async function sendSignResponse(connectionId, sequence, signedTxHex) {
-  if (!_manager) throw new Error('Manager not initialized')
-  await _manager.sendSignResponse(connectionId, sequence, signedTxHex)
+  const manager = await getManager()
+  await manager.sendSignResponse(connectionId, sequence, signedTxHex)
 }
 
 export async function sendSignError(connectionId, sequence, errorMessage) {
-  if (!_manager) throw new Error('Manager not initialized')
-  await _manager.sendSignError(connectionId, sequence, errorMessage)
+  const manager = await getManager()
+  await manager.sendSignError(connectionId, sequence, errorMessage)
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes a "Manager not initialized" toast that can show up when scanning/pasting a `wiz://` URI.

If `wizardconnect/init` silently returns at boot (its catch swallows `getMnemonic` failures — vault not ready yet, etc.), `_manager` is never populated. Nothing re-invokes `getManager()` for the rest of the session, so any `pair` call throws "Manager not initialized" and the user can't pair any dApp until they refresh the page.

The fix calls `getManager()` inside the three entry points that need it, instead of asserting that init already did so. Memoized, so it's only real work once.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes

No existing unit/e2e coverage for this module. Manual repro: temporarily `throw` at the top of the init action, reload, then try to scan/paste any `wiz://` URI. Before: error toast. After: pair proceeds normally.