### PR TITLE
fix: preserve exact BCH amount when market price changes

### DIFF
--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -862,10 +862,6 @@ export default {
           if (!amount || amount <= 0) return
 
           this.recipients[i].fiatAmount = this.convertToFiatAmount(amount)
-          this.recipients[i].amount = sendPageUtils.convertFiatToSelectedAsset(
-            this.recipients[i].fiatAmount, this.selectedAssetMarketPrice,
-            this.assetId === 'bch' ? 8 : (this.asset?.decimals ?? 0)
-          )
           this.inputExtras[i].fiatFormatted = formatWithLocale(
             this.recipients[i].fiatAmount, this.decimalObj(true)
           )


### PR DESCRIPTION
## Summary

When a user enters a specific BCH amount (not fiat) in the send page, the amount was being incorrectly overwritten whenever the market price updated. This caused the sent amount to differ from what the user specified.

## Problem

User reported: Entered 0.01 BCH to send, but Paytaca sent 0.00999655 BCH instead.

The root cause was in the selectedAssetMarketPrice watcher in send.vue. When price updated:
1. It read the BCH amount (e.g., 0.01)
2. Converted to fiat (e.g., ~0.41 PHP)
3. Converted fiat back to BCH (0.00999655 PHP / price)
4. Overwrote the original BCH amount with this rounded value

This roundtrip conversion caused precision loss since fiat is typically displayed with 2 decimals.

## Fix

Removed the line that overwrites recipient.amount in the price watcher. Now when price changes:
- Only the fiat display value (fiatAmount, fiatFormatted) is updated
- The BCH amount (recipient.amount) remains exactly as the user entered it
- The BCH display formatting (amountFormatted) is also preserved

This ensures:
- BCH input mode: User exact BCH amount is never affected by price fluctuations
- Fiat input mode: Fiat amount stays the same, BCH amount is correctly recalculated when price changes

## Files Changed

- src/pages/transaction/send.vue - Removed 4 lines that incorrectly recalculated BCH amount from fiat on price change