### PR TITLE
fix: improve swipe button width and touch target on small screens

### DIFF
--- a/src/components/drag-slide.vue
+++ b/src/components/drag-slide.vue
@@ -2,12 +2,12 @@
   <!-- Root must be an actual element so directives on <DragSlide> can attach -->
   <div :class="{ 'absolute-bottom': !disableAbsoluteBottom, 'br-15': true, 'drag-slide-container': true }">
     <q-list v-if="!swiped">
-      <div style="margin-bottom: 20px; margin-left: 10%; margin-right: 10%;">
+      <div style="margin-bottom: 20px; margin-left: 5%; margin-right: 5%;">
         <q-slide-item
           left-color="blue"
           @left="slide"
           :disable="disable"
-          style="background-color: transparent; border-radius: 40px;"
+          style="background-color: transparent; border-radius: clamp(30px, 10vw, 40px); min-width: 200px;"
         >
           <template v-if="!disable" v-slot:left>
             <div style="font-size: 15px" class="text-body1">
@@ -24,7 +24,7 @@
               <q-icon v-else name="mdi-chevron-double-right" size="xl" class="bg-blue" style="border-radius: 50%" />
             </q-item-section>
             <q-item-section class="text-right">
-              <h5 class="q-my-sm text-grey-4 text-uppercase" style="font-size: large;">{{ sliderText }}</h5>
+              <h5 class="q-my-sm text-grey-4 text-uppercase" style="font-size: clamp(14px, 3.5vw, 18px);">{{ sliderText }}</h5>
             </q-item-section>
           </q-item>
         </q-slide-item>

--- a/src/components/ramp/fiat/dialogs/RampDragSlide.vue
+++ b/src/components/ramp/fiat/dialogs/RampDragSlide.vue
@@ -3,7 +3,7 @@
   <div class="ramp-drag-slide-root">
     <div v-if="!swiped" v-bind="$attrs" class="ramp-drag-slide-container absolute-bottom" :class="{ nudge }">
       <div class="drag-slide-inner">
-        <q-slide-item :left-color="themeColor" @left="slide" style="background: transparent; border-radius: 40px;">
+        <q-slide-item :left-color="themeColor" @left="slide" style="background: transparent; border-radius: clamp(30px, 10vw, 40px); min-width: 200px;">
           <template v-if="!locked" v-slot:left>
             <div style="font-size: 15px" class="text-body1">
               <q-icon class="material-icons q-mr-md" size="lg">task_alt</q-icon>
@@ -197,8 +197,8 @@ export default {
 
 .drag-slide-inner {
   margin-bottom: 16px;
-  margin-left: 10%;
-  margin-right: 10%;
+  margin-left: 5%;
+  margin-right: 5%;
   background: transparent;
   position: relative;
   z-index: 4501;


### PR DESCRIPTION
$(cat <<EOF
## Summary

The swipe-to-confirm button in eload service (and other services using the DragSlide component) was too compressed on small Android devices, making it difficult or impossible to swipe.

## Problem

On Android devices with small resolutions (e.g., 320px width):
- The swipe button had `margin-left: 10%` and `margin-right: 10%`, leaving only 80% of screen width for the button
- A fixed `border-radius: 40px` did not scale with screen size
- No minimum width constraint meant the touch target could become too small

## Solution

Applied fixes to both `drag-slide.vue` and `RampDragSlide.vue` components:

1. **Reduced side margins**: Changed from `10%` to `5%` → button now occupies 90% of screen width instead of 80%

2. **Responsive border-radius**: Changed from fixed `40px` to `clamp(30px, 10vw, 40px)` → scales proportionally on smaller screens

3. **Added minimum width**: Added `min-width: 200px` to ensure a minimum touch target remains usable on tiny displays

4. **Responsive font-size**: Changed from `font-size: large` to `clamp(14px, 3.5vw, 18px)` for the button text

## Files Changed

- `src/components/drag-slide.vue` - Used by 14 files across the app (send, eload, marketplace, cauldron, etc.)
- `src/components/ramp/fiat/dialogs/RampDragSlide.vue` - Used by 3 files (EscrowTransfer, PaymentConfirmation, AppealDetail)

## Testing

- On small Android devices: Button should now have adequate width and touch target
- On larger screens/desktop: Changes should have no visible impact as clamp() values will use upper bounds

EOF
)