### PR TITLE
fix: BigInt deserialization in WizardConnect and light mode text colors

### DIFF
--- a/src/components/walletconnect/PeerInfo.vue
+++ b/src/components/walletconnect/PeerInfo.vue
@@ -9,12 +9,12 @@
       <q-item-section>
         <q-item-label>
           <slot name="name">
-            <span class="text-bold">{{ metadata?.name}}</span>
+            <span class="text-bold text-bow" :class="getDarkModeClass(darkMode)">{{ metadata?.name}}</span>
           </slot>
         </q-item-label>
         <q-item-label caption>
           <slot name="url">
-            <div class="session-info-attribute-url" :class="getDarkModeClass(darkMode)" style="word-break: break-all">{{ metadata?.url  }}</div>
+            <div class="session-info-attribute-url text-bow" :class="getDarkModeClass(darkMode)" style="word-break: break-all">{{ metadata?.url  }}</div>
             <div v-if="sessionId" class="session-info-attribute" :class="getDarkModeClass(darkMode)">Sid: {{ sessionId  }}</div>
             <div v-if="sessionTopic" class="session-info-attribute" :class="getDarkModeClass(darkMode)">Topic: {{ sessionTopic?.replace(sessionTopic.slice(3, sessionTopic.length - 6), '...')  }}</div>
           </slot>

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -151,7 +151,7 @@
           </div>
         </div>
         <div class="row">
-          <div v-if="activeSessionsCount > 0" class="col-xs-12 text-bold q-px-sm q-mt-md q-mb-sm">
+          <div v-if="activeSessionsCount > 0" class="col-xs-12 text-bold q-px-sm q-mt-md q-mb-sm text-bow" :class="getDarkModeClass(darkMode)">
             <span class="text-h6">{{ $t('ConnectedApps', {}, 'Connected Apps') }}</span>
             <q-badge v-if="activeSessionsCount > 0" color="green" class="q-ml-sm">
               {{ activeSessionsCount }}

--- a/src/pages/apps/wizard-connect.vue
+++ b/src/pages/apps/wizard-connect.vue
@@ -68,7 +68,7 @@
 
       <div class="row">
         <div class="col-xs-12">
-          <div v-if="connectionList.length > 0" class="col-xs-12 text-bold q-px-sm q-mt-md q-mb-md">
+          <div v-if="connectionList.length > 0" class="col-xs-12 text-bold q-px-sm q-mt-md q-mb-md text-bow" :class="getDarkModeClass(darkMode)">
             <span class="text-h6">{{ $t('ConnectedApps', {}, 'Connected Apps') }}</span>
             <q-badge color="green" class="q-ml-sm">
               {{ connectionList.length }}
@@ -94,10 +94,10 @@
                   </q-item-section>
                   <q-item-section>
                     <q-item-label>
-                      <span class="text-bold">{{ conn.dappName || 'Connecting...' }}</span>
+                      <span class="text-bold text-bow" :class="getDarkModeClass(darkMode)">{{ conn.dappName || 'Connecting...' }}</span>
                     </q-item-label>
                     <q-item-label caption>
-                      <div class="text-light session-info-attribute-url" style="word-break: break-all">{{ conn.dappUrl
+                      <div class="session-info-attribute-url text-bow" :class="getDarkModeClass(darkMode)" style="word-break: break-all">{{ conn.dappUrl
                         }}
                       </div>
                       <div class="q-mt-xs">

--- a/src/wallet/wizardconnect/service.js
+++ b/src/wallet/wizardconnect/service.js
@@ -1,6 +1,6 @@
 // import { WalletConnectionManager } from '@wizardconnect/wallet'
 import { mnemonicToSeedSync } from 'bip39'
-import { toUint8Array } from '@wizardconnect/core'
+import { toUint8Array, toBigInt } from '@wizardconnect/core'
 import {
   deriveHdPrivateNodeFromSeed,
   deriveHdPrivateNodeChild,
@@ -184,7 +184,7 @@ export async function sendSignError(connectionId, sequence, errorMessage) {
  * sourceOutputToRelay serializer) or as extended JSON (`<Uint8Array: 0x...>`).
  * BigInts arrive as extended JSON (`<bigint: Xn>`). The toUint8Array
  * helper from @wizardconnect/core handles Uint8Array deserialization.
- * BigInt values are parsed using native BigInt() constructor.
+ * BigInt values are parsed using toBigInt from @wizardconnect/core.
  *
  * Zero-length placeholder unlockingBytecode is dropped — downstream compiler
  * logic treats an absent property as a placeholder.
@@ -198,7 +198,7 @@ function hydrateSourceOutput(so) {
     outpointTransactionHash: toUint8Array(so.outpointTransactionHash),
     outpointIndex: so.outpointIndex,
     sequenceNumber: so.sequenceNumber,
-    valueSatoshis: BigInt(so.valueSatoshis),
+    valueSatoshis: toBigInt(so.valueSatoshis),
     lockingBytecode: toUint8Array(so.lockingBytecode),
     ...(hasUnlocking && { unlockingBytecode: toUint8Array(so.unlockingBytecode) }),
     ...(so.token && { token: hydrateToken(so.token) }),
@@ -208,7 +208,7 @@ function hydrateSourceOutput(so) {
 function hydrateToken(token) {
   return {
     category: toUint8Array(token.category),
-    amount: BigInt(token.amount),
+    amount: toBigInt(token.amount),
     ...(token.nft && { nft: hydrateNft(token.nft) }),
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes two issues in the WizardConnect and WalletConnect flows:

### 1. Primary fix — BigInt deserialization crash in WizardConnect signing
When a dApp sends a `signRequest` through WizardConnect, `sourceOutputs` and token `amount` values arrive over the wire as serialized JSON. `BigInt` values do not survive native JSON serialization — they may come through as extended JSON (`<bigint: Xn>`) or strings. Using the native `BigInt()` constructor on these formats throws, causing `signRequest()` to crash during transaction hydration.

**Fix:** Replace native `BigInt()` with `toBigInt` from `@wizardconnect/core`, which correctly handles the various wire formats.

### 2. Secondary fix — unreadable white text in light mode
Quasar has dark mode globally enabled (`dark: true`), which sets the default body text color to white. Several elements in WizardConnect (`wizard-connect.vue`) and WalletConnect (`WalletConnectV2.vue`, `PeerInfo.vue`) were missing the `text-bow` + `getDarkModeClass()` bindings, causing them to render white text on light backgrounds.

**Fix:** Add `text-bow` and dark/light class bindings to:
- "Connected Apps" headings
- Dapp names and URLs

## Files changed
- `src/wallet/wizardconnect/service.js`
- `src/pages/apps/wizard-connect.vue`
- `src/components/walletconnect/WalletConnectV2.vue`
- `src/components/walletconnect/PeerInfo.vue`