### PR TITLE
fix(wizardconnect): suppress duplicate sign requests after reconnects

### DIFF
--- a/patches/@wizardconnect+wallet+0.1.10.patch
+++ b/patches/@wizardconnect+wallet+0.1.10.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js b/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
+index 15c3fce..8a2e339 100644
+--- a/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
++++ b/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
+@@ -137,7 +137,6 @@ export class WalletConnectionManager extends EventEmitter {
+         if (!conn?.client) {
+             throw new Error(`Connection ${connectionId} not found or not connected`);
+         }
+-        this.activeSignSequences.delete(sequence);
+         const response = {
+             action: RelayMsgAction.SignTransactionResponse,
+             sequence,
+@@ -145,6 +144,7 @@ export class WalletConnectionManager extends EventEmitter {
+             time: Math.floor(Date.now() / 1000),
+         };
+         await conn.client.relay(response);
++        this.activeSignSequences.delete(sequence);
+     }
+     /**
+      * Send a sign error response back to the dapp.
+@@ -154,7 +154,6 @@ export class WalletConnectionManager extends EventEmitter {
+         if (!conn?.client) {
+             return; // Already disconnected, nothing to do
+         }
+-        this.activeSignSequences.delete(sequence);
+         const response = {
+             action: RelayMsgAction.SignTransactionResponse,
+             sequence,
+@@ -163,6 +162,7 @@ export class WalletConnectionManager extends EventEmitter {
+             time: Math.floor(Date.now() / 1000),
+         };
+         await conn.client.relay(response);
++        this.activeSignSequences.delete(sequence);
+     }
+     // --- Private connection lifecycle ---
+     /** Immediately attempt to flush the notification queue (fire-and-forget). */

--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -59,11 +59,11 @@ function serializeConnection (id, conn) {
   }
 }
 
-export async function init ({ commit, dispatch, rootGetters }) {
+export async function init ({ commit, dispatch, rootGetters, state }) {
   const walletIndex = rootGetters['global/getWalletIndex'] || 0
   const isChipnet = rootGetters['global/isChipnet'] || false
   const walletHash = rootGetters['global/getWallet']?.('bch')?.walletHash || null
-  
+
   wizardConnectService.setWalletConfig(walletIndex, isChipnet, walletHash)
 
   let manager
@@ -108,8 +108,14 @@ export async function init ({ commit, dispatch, rootGetters }) {
     dispatch('handleRemoteDisconnect', { connectionId, reason, message })
   })
 
-  // Clear stale pending requests from previous session
-  commit('clearPendingRequests')
+  // Only clear stale state on a true fresh session (app start / no existing
+  // connections). Re-inits triggered by pull-to-refresh or page navigation
+  // must NOT wipe active pending requests / processed keys.
+  const isFreshSession = Object.keys(state.connections || {}).length === 0
+  if (isFreshSession) {
+    commit('clearPendingRequests')
+    commit('clearProcessedKeys')
+  }
 
   // Restore saved connections for this wallet
   const savedUris = loadSavedUris(walletHash)
@@ -130,6 +136,7 @@ export async function init ({ commit, dispatch, rootGetters }) {
 export function reset ({ commit }) {
   wizardConnectService.reset()
   commit('clearPendingRequests')
+  commit('clearProcessedKeys')
   commit('setConnections', {})
 }
 
@@ -150,15 +157,21 @@ export async function disconnect ({ commit, state, rootGetters }, { connectionId
   }
   wizardConnectService.disconnect(connectionId)
   commit('removeConnection', connectionId)
+  commit('removeProcessedKeysForConnection', connectionId)
 }
 
 export async function handleSignRequest ({ commit, state }, pending) {
   const sequence = pending.request?.sequence
-  const cancelledKey = `${pending.connectionId}:${sequence}`
+  const key = `${pending.connectionId}:${sequence}`
 
   // Check if this request was already cancelled (race condition)
-  if (state.cancelledKeys.includes(cancelledKey)) {
-    commit('removeCancelledKey', cancelledKey)
+  if (state.cancelledKeys.includes(key)) {
+    commit('removeCancelledKey', key)
+    return
+  }
+
+  // Ignore if already approved/rejected so reconnects don't re-prompt
+  if (state.processedKeys.includes(key)) {
     return
   }
 
@@ -173,6 +186,7 @@ export async function handleSignRequest ({ commit, state }, pending) {
 
 export async function approveRequestWithData ({ commit }, { connectionId, sequence, transactionJson }) {
   commit('removePendingRequest', { connectionId, sequence })
+  commit('addProcessedKey', `${connectionId}:${sequence}`)
   try {
     const request = JSON.parse(transactionJson)
     const signedTxHex = await wizardConnectService.signRequest(request)
@@ -189,6 +203,7 @@ export async function approveRequestWithData ({ commit }, { connectionId, sequen
 
 export async function rejectRequest ({ commit }, { connectionId, sequence }) {
   commit('removePendingRequest', { connectionId, sequence })
+  commit('addProcessedKey', `${connectionId}:${sequence}`)
   try {
     await wizardConnectService.sendSignError(connectionId, sequence, 'User rejected')
   } catch {
@@ -203,6 +218,7 @@ export function handleSignCancelled ({ commit, state }, { connectionId, sequence
   )
   if (exists) {
     commit('removePendingRequest', { connectionId, sequence })
+    commit('addProcessedKey', key)
   } else {
     commit('addCancelledKey', key)
   }
@@ -215,6 +231,7 @@ export function handleRemoteDisconnect ({ commit, state, rootGetters }, { connec
     removeSavedUri(walletHash, connection.uri)
   }
   commit('removeConnection', connectionId)
+  commit('removeProcessedKeysForConnection', connectionId)
 
   // Remove any pending requests for this connection
   const pending = state.pendingRequests.filter(r => r.connectionId === connectionId)

--- a/src/store/wizardconnect/mutations.js
+++ b/src/store/wizardconnect/mutations.js
@@ -54,3 +54,21 @@ export function removeCancelledKey (state, key) {
   if (!state) return
   state.cancelledKeys = (state.cancelledKeys || []).filter(k => k !== key)
 }
+
+export function addProcessedKey (state, key) {
+  if (!state) return
+  if (!state.processedKeys.includes(key)) {
+    state.processedKeys = [...(state.processedKeys || []), key]
+  }
+}
+
+export function removeProcessedKeysForConnection (state, connectionId) {
+  if (!state) return
+  const prefix = `${connectionId}:`
+  state.processedKeys = (state.processedKeys || []).filter(k => !k.startsWith(prefix))
+}
+
+export function clearProcessedKeys (state) {
+  if (!state) return
+  state.processedKeys = []
+}

--- a/src/store/wizardconnect/state.js
+++ b/src/store/wizardconnect/state.js
@@ -2,6 +2,7 @@ export default function () {
   return {
     connections: {},
     pendingRequests: [],
-    cancelledKeys: []
+    cancelledKeys: [],
+    processedKeys: []
   }
 }


### PR DESCRIPTION
## Problem

When a transaction is approved via WizardConnect and the WebSocket relay drops before the response is delivered, the same sign request repeatedly re-appears for approval after every reconnect cycle. The user sees a flicker: the dialog shows up and is auto-cleaned, then shows up again on the next reconnect.

Console shows:
```
[Warning] [wizardconnect/dapp] No pending request for sequence: 3850746605262824
```

## Root Cause

There are **three** interacting issues:

1. **Library-level premature dedup clear** (`@wizardconnect/wallet`)  
   `sendSignResponse` and `sendSignError` remove the sequence from `activeSignSequences` **before** calling `await conn.client.relay()`. If the connection fails during that await, the wallet has already forgotten it was handling that request. When the dapp re-sends the pending request after reconnect, the library treats it as brand-new and emits another `pendingSignRequest`.

2. **Store-level missing guard**  
   The Paytaca store had no record of which sequences had already been approved/rejected. Even if we fixed the library, relay-level redelivery of old messages could still reach the UI layer.

3. **`init()` unconditionally wipes pending requests**  
   `wizardconnect/init` was called on every pull-to-refresh and page navigation. It ran `commit('clearPendingRequests')`, which caused an "auto-clean" effect: the dialog vanished, only to reappear on the next reconnect-triggered event.

## Changes

### `@wizardconnect/wallet` patch
Moves `activeSignSequences.delete(sequence)` to **after** the `await conn.client.relay(response)` call in both `sendSignResponse` and `sendSignError`. If relay fails, the sequence stays in the dedup set and the re-sent message is silently dropped by the library.

### Store-level `processedKeys`
- Added `processedKeys: []` to wizardconnect state.
- `approveRequestWithData`, `rejectRequest`, and `handleSignCancelled` now push `${connectionId}:${sequence}` into `processedKeys`.
- `handleSignRequest` silently ignores any incoming request whose key is already in `processedKeys`.
- Keys are cleared when:
  - User calls `disconnect()`
  - `handleRemoteDisconnect()` fires
  - `reset()` is called (wallet switch)
  - `init()` runs on a **fresh session** only (empty connections state)

### `init()` cleanup fix
`init()` now only clears `pendingRequests` and `processedKeys` when `state.connections` is empty (true app start). Re-inits triggered by pull-to-refresh or page navigation preserve active requests so dialogs don't disappear.

## Testing Notes

- Approve a WizardConnect transaction, then force a relay disconnect (airplane mode / network toggle).
- The sign request dialog should **not** re-appear after reconnect.
- Disconnecting the dApp manually and reconnecting fresh should allow new requests again.