### PR TITLE
feat(wizardconnect): parallel broadcast via watchtower

### DIFF
--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -1,4 +1,5 @@
 import * as wizardConnectService from 'src/wallet/wizardconnect/service'
+import Watchtower from 'watchtower-cash-js'
 import { Notify } from 'quasar'
 
 function getStorageKey(walletHash) {
@@ -184,12 +185,20 @@ export async function handleSignRequest ({ commit, state }, pending) {
   })
 }
 
-export async function approveRequestWithData ({ commit }, { connectionId, sequence, transactionJson }) {
+export async function approveRequestWithData ({ commit, rootGetters }, { connectionId, sequence, transactionJson }) {
   commit('removePendingRequest', { connectionId, sequence })
   commit('addProcessedKey', `${connectionId}:${sequence}`)
   try {
     const request = JSON.parse(transactionJson)
     const signedTxHex = await wizardConnectService.signRequest(request)
+
+    // Fire-and-forget broadcast via watchtower (redundant to dApp broadcast)
+    const isChipnet = rootGetters['global/isChipnet'] || false
+    const watchtower = new Watchtower(isChipnet)
+    watchtower.BCH.broadcastTransaction(signedTxHex).catch(err => {
+      console.log('WizardConnect: wallet-side broadcast (redundant) failed or tx already known:', err)
+    })
+
     await wizardConnectService.sendSignResponse(connectionId, sequence, signedTxHex)
   } catch (err) {
     console.error('WizardConnect: sign error:', err)


### PR DESCRIPTION
## Summary
Currently, WizardConnect signs transactions in the wallet and returns the signed hex to the dApp, leaving **all broadcasting responsibility to the dApp**. If the dApp's broadcast fails (network issues, provider downtime, etc.), the transaction may be lost even though the wallet has already signed it.

This PR adds a **redundant, fire-and-forget broadcast** from the wallet side via Watchtower immediately after signing, improving transaction reliability without changing the existing dApp flow.

## What Changed
- In `approveRequestWithData`, after signing the transaction, the wallet now also broadcasts the signed hex to Watchtower in parallel.
- The broadcast is **non-blocking**: `sendSignResponse` is still sent to the dApp immediately. Watchtower broadcast failures are caught and logged, never interrupting the dApp response.

## Why This Is Safe
1. **Deterministic transaction hex** — The signed transaction is immutable. Both the wallet and dApp push the exact same bytes.
2. **No Replace-By-Fee (RBF)** — BCH does not support RBF, so there is no risk of the transaction being altered or double-spent after the first broadcast.
3. **Idempotent mempool behavior** — If the transaction is already in the mempool (e.g., dApp broadcasted first), Watchtower returns a benign `"already known"` error. The network is designed to handle duplicate broadcasts.
4. **Fire-and-forget** — We do not wait for or depend on the Watchtower broadcast to succeed. The dApp still receives the signed hex immediately and can broadcast independently.

## Benefits
- **Improved reliability**: Even if the dApp fails to broadcast, the wallet has already propagated the transaction.
- **Better UX**: Users don't have to retry or worry about a silent dApp broadcast failure.
- **Backward compatible**: No changes to the dApp protocol or sign response format.

## Testing
- [ ] Connect to a WizardConnect dApp and approve a transaction.
- [ ] Verify the dApp receives the signed hex as before.
- [ ] Check wallet logs for the redundant broadcast attempt (success or "already known").