### PR TITLE
fix(android): prevent crash on GrapheneOS / Android 14+ due to missing receiver export flag

### DIFF
--- a/src-capacitor/patches/@capacitor+share+5.0.8.patch
+++ b/src-capacitor/patches/@capacitor+share+5.0.8.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/@capacitor/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java b/node_modules/@capacitor/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+index 63b3635..2fa6895 100644
+--- a/node_modules/@capacitor/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
++++ b/node_modules/@capacitor/share/android/src/main/java/com/capacitorjs/plugins/share/SharePlugin.java
+@@ -41,7 +41,11 @@ public class SharePlugin extends Plugin {
+                     }
+                 }
+             };
+-        getActivity().registerReceiver(broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT));
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
++            getActivity().registerReceiver(broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT), Context.RECEIVER_NOT_EXPORTED);
++        } else {
++            getActivity().registerReceiver(broadcastReceiver, new IntentFilter(Intent.EXTRA_CHOSEN_COMPONENT));
++        }
+     }
+ 
+     @SuppressWarnings("deprecation")


### PR DESCRIPTION
## Summary

Fixes a startup crash on GrapheneOS (and other Android 14+ builds) caused by `@capacitor/share` calling `registerReceiver` without specifying `RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED`.

## Crash Details

```
java.lang.SecurityException: com.paytaca.app: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
```

- **OS:** GrapheneOS (Android 16)
- **Target SDK:** 35
- **Affected plugin:** `@capacitor/share` v5.0.8
- **Trigger:** App launch → `MainActivity.onCreate` → `Bridge` initialization → `SharePlugin.load()` → `registerReceiver(...)` without flags

## Root Cause

Android 14 (API 34) introduced a requirement that non-system broadcast receivers must explicitly declare their export status when registered dynamically. The version of `@capacitor/share` currently used (v5.0.8) predates this requirement and calls the legacy two-argument `registerReceiver` overload, causing a fatal `SecurityException` on modern Android.

## Fix

Patches `@capacitor/share` via `patch-package` to use the three-argument `registerReceiver` overload with `Context.RECEIVER_NOT_EXPORTED` when running on Android 14+ (API 34 / `UPSIDE_DOWN_CAKE`). On older versions it falls back to the original two-argument call.

**Why `RECEIVER_NOT_EXPORTED`?**
The broadcast receiver in `SharePlugin` is only used internally to capture the chosen share target (`Intent.EXTRA_CHOSEN_COMPONENT`) via a `PendingIntent`. It does not need to receive broadcasts from external apps, so `NOT_EXPORTED` is the correct (and safest) choice.

## Files Changed

- `src-capacitor/patches/@capacitor+share+5.0.8.patch` — new patch applied automatically by `patch-package` on `postinstall`

## Testing Notes

- [ ] Clean install on Android 14/15/16 device or emulator
- [ ] Launch app — should no longer crash at startup
- [ ] Trigger Share → verify share sheet opens and chosen component is captured correctly

## Long-term

This patch can be removed once the project upgrades to `@capacitor/share` >= 6.x (or whichever version includes the upstream fix).