### PR TITLE
feat(eload): add order status polling and check status button

### DIFF
--- a/src/pages/apps/eload/eload-form.vue
+++ b/src/pages/apps/eload/eload-form.vue
@@ -48,6 +48,15 @@
 				</div>
 			</q-card>
 
+			<div v-if="purchaseOrderId" class="q-mt-md">
+				<q-btn
+					class="full-width button"
+					rounded
+					label="Check Order Status"
+					@click="goToOrderStatus()"
+				/>
+			</div>
+
 			<div class="q-mt-md">
 				<q-btn
 					class="full-width button"
@@ -445,6 +454,7 @@ export default {
 			addressTouched: false,
 			purchaseSuccess: false,
 			purchaseTxid: '',
+			purchaseOrderId: '',
 			phpBchRate: null,
 			phpBchPriceQuoteId: null,
 			phpBchRateLoading: false,
@@ -938,6 +948,7 @@ export default {
 				// Mark this payload as successfully prepared. This must be set only on success;
 				// otherwise, a failed request could block watcher-triggered retries.
 				vm.txnPrepareKey = key
+				vm.purchaseOrderId = result?.data?.id || ''
 				vm.clearTxnPrepareAutoRetry()
 				return true
 			} catch (error) {
@@ -1071,9 +1082,17 @@ export default {
 				window.open(url, '_blank', 'noopener')
 			}
 		},
+		goToOrderStatus () {
+			if (!this.purchaseOrderId) return
+			this.$router.push({
+				name: 'eload-service-order-details',
+				params: { orderId: this.purchaseOrderId }
+			})
+		},
 		resetPurchase () {
 			this.purchaseSuccess = false
 			this.purchaseTxid = ''
+			this.purchaseOrderId = ''
 			this.buying = false
 
 			// Reset prepared txn state

--- a/src/pages/apps/eload/eload-history-details.vue
+++ b/src/pages/apps/eload/eload-history-details.vue
@@ -161,7 +161,8 @@ export default {
 			order: null,
 			loading: true,
 			promoSnapshot: null,
-			loadError: ''
+			loadError: '',
+			pollTimer: null
 		}
 	},
 	computed: {
@@ -190,6 +191,10 @@ export default {
 	},
 	async mounted () {
 		await this.fetchOrder()
+		this.startPolling()
+	},
+	beforeUnmount () {
+		this.stopPolling()
 	},
 	methods: {	
 		getStatusLabel (order) {
@@ -210,11 +215,28 @@ export default {
 			await this.fetchOrder()
 			done()
 		},
-		async fetchOrder () {
-			this.loading = true
-			this.loadError = ''
-			this.order = null
-			this.promoSnapshot = null
+		isTerminalStatus (status) {
+			return ['success', 'failed'].includes(status)
+		},
+		startPolling () {
+			if (this.pollTimer) return
+			this.pollTimer = setInterval(() => {
+				this.fetchOrder(true)
+			}, 10000)
+		},
+		stopPolling () {
+			if (this.pollTimer) {
+				clearInterval(this.pollTimer)
+				this.pollTimer = null
+			}
+		},
+		async fetchOrder (isPoll = false) {
+			if (!isPoll) {
+				this.loading = true
+				this.loadError = ''
+				this.order = null
+				this.promoSnapshot = null
+			}
 			const orderID = this.$route.params.orderId
 
 			try {
@@ -223,14 +245,21 @@ export default {
 				if (result?.success) {
 					this.order = result.data || {}
 					this.promoSnapshot = (result.data && result.data.promo_snapshot) ? result.data.promo_snapshot : {}
-				} else {
+					if (this.isTerminalStatus(this.order?.status)) {
+						this.stopPolling()
+					}
+				} else if (!isPoll) {
 					this.loadError = result?.error?.message || result?.error || this.$t?.('UnableToLoad') || 'Request failed'
 				}
 			} catch (e) {
 				console.error('[Eload] fetchOrderDetails failed:', e)
-				this.loadError = this.$t?.('UnableToLoad') || 'Request failed'
+				if (!isPoll) {
+					this.loadError = this.$t?.('UnableToLoad') || 'Request failed'
+				}
 			} finally {
-				this.loading = false
+				if (!isPoll) {
+					this.loading = false
+				}
 			}
 		},
 		copyToClipboard (value) {


### PR DESCRIPTION
## Summary

- Added 'Check Order Status' button on the eload payment success page. Clicking it navigates to the order details page using the order ID returned from the create order API.
- Implemented 10-second polling on the order status (details) page to keep the order state up-to-date without manual refresh.
- Polling automatically stops once the order reaches a terminal state: 'success' or 'failed' (including refunded orders).