### PR TITLE
Improvements/transaction details

### DIFF
--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -1196,10 +1196,18 @@ export default {
       const txid = this.txid || this.$route?.params?.txid
       if (!txid) return
 
+
+      let backNavQueryData;
+      try {
+        backNavQueryData = btoa(JSON.stringify(this.$route.query));
+      } catch (error) {
+        console.error(error);
+      }
+
       this.$router.push({
         name: 'transaction-summary',
         params: { txid },
-        query: { from: 'detail' }
+        query: { from: 'detail', backNavQueryData },
       })
     },
     async fetchAndShow (retryAttempt = 0) {

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -107,6 +107,19 @@
           </div>
         </div>
 
+        <div v-if="walletHistoryCount > 1" class="q-mt-md q-mb-lg text-center">
+          <q-btn
+            no-caps
+            rounded
+            outline
+            color="pt-primary1"
+            :label="$t('ViewAllAssets', {}, 'View All Assets')"
+            icon="list"
+            @click="goToTransactionSummary"
+            class="view-all-assets-btn"
+          />
+        </div>
+
         <!-- NFT Image Display -->
         <div v-if="isNft && tx && tx.asset" class="q-mt-md q-mb-lg text-center">
           <div v-if="fetchingNftMetadata" class="nft-image-skeleton-container">
@@ -452,6 +465,7 @@ export default {
       denominationTabSelected: 'BCH',
       loadError: '',
       tx: null,
+      walletHistoryCount: 0,
       isLoading: false,
       retryCount: 0,
       maxRetries: 7,
@@ -986,6 +1000,7 @@ export default {
         this.loadMemo()
         this.loadFavorites()
         this.fetchTokenPrice()
+        this.fetchWalletHistoryCount()
         // Launch confetti if this is a new transaction
         // Wait for DOM to be fully rendered before triggering
         if (isNewTransaction) {
@@ -1049,6 +1064,7 @@ export default {
       if (newTx && newTx.txid && (!oldTx || oldTx.txid !== newTx.txid)) {
         this.$nextTick(() => {
           this.loadMemo()
+          this.fetchWalletHistoryCount()
         })
       }
       // Fetch NFT metadata when transaction changes and it's an NFT
@@ -1158,6 +1174,34 @@ export default {
     hexToRef (hex6) {
       return hexToRefUtil(hex6)
     },
+    async fetchWalletHistoryCount() {
+      /**
+       * Checks from backend if the current txid has more than one wallet histories,
+       * this is an indicator to show a button that redirects to transaction summary
+       */
+      const effectiveWalletHash = this.walletHash || this.$store.getters['global/getWallet']('bch')?.walletHash
+      const effectiveTxid = this.txid || this.$route?.params?.txid
+      if (!effectiveWalletHash || !effectiveTxid) {
+        this.walletHistoryCount = -1;
+        return;
+      }
+
+      const baseUrl = getWatchtowerApiUrl(this.$store.getters['global/isChipnet']);
+      const url = `${baseUrl}/history/wallet/${encodeURIComponent(effectiveWalletHash)}/`
+      const params = { txids: effectiveTxid, all: true, page_size: 1 };
+      const { data } = await axios.get(url, { params });
+      this.walletHistoryCount = data.num_pages;
+    },
+    async goToTransactionSummary () {
+      const txid = this.txid || this.$route?.params?.txid
+      if (!txid) return
+
+      this.$router.push({
+        name: 'transaction-summary',
+        params: { txid },
+        query: { from: 'detail' }
+      })
+    },
     async fetchAndShow (retryAttempt = 0) {
       this.isLoading = true
       this.loadError = ''
@@ -1233,6 +1277,7 @@ export default {
             }
             this.loadFavorites()
             this.fetchTokenPrice()
+            this.fetchWalletHistoryCount();
             // Launch confetti if this is a new transaction
             // Wait for DOM to be fully rendered before triggering
             if (isNewTransaction) {
@@ -1263,6 +1308,7 @@ export default {
               this.loadMemo()
               this.loadFavorites()
               this.fetchTokenPrice()
+              this.fetchWalletHistoryCount()
               if (isNewTransaction) {
                 this.waitForRenderAndLaunchConfetti()
               }
@@ -1297,6 +1343,7 @@ export default {
               
               this.$nextTick(() => {
                 this.loadMemo()
+                this.fetchWalletHistoryCount()
                 if (isNewTransaction) {
                   this.waitForRenderAndLaunchConfetti()
                 }
@@ -1335,6 +1382,7 @@ export default {
             this.loadMemo()
             this.loadFavorites()
             this.fetchTokenPrice()
+            this.fetchWalletHistoryCount()
             if (isNewTransaction) {
               this.waitForRenderAndLaunchConfetti()
             }
@@ -1373,6 +1421,7 @@ export default {
             
             this.$nextTick(() => {
               this.loadMemo()
+              this.fetchWalletHistoryCount()
               if (isNewTransaction) {
                 this.waitForRenderAndLaunchConfetti()
               }
@@ -1457,6 +1506,7 @@ export default {
               this.loadMemo()
               this.loadFavorites()
               this.fetchTokenPrice()
+              this.fetchWalletHistoryCount()
             })
           } else {
             // Not found yet, retry with exponential backoff

--- a/src/pages/transactions/TransactionSummary.vue
+++ b/src/pages/transactions/TransactionSummary.vue
@@ -175,6 +175,7 @@ const darkMode = computed(() => $store.getters['darkmode/getStatus'])
 const props = defineProps({
   txid: String,
   from: String,
+  backNavQueryData: String,
 })
 
 const walletHash = computed(() => {
@@ -213,6 +214,18 @@ const transactionContentData = computed(() => {
 
 const backNavPath = computed(() => {
   if (props.from === 'send' || props.from === 'send-page') return '/send'
+  if (props.from === 'detail') {
+    let query;
+    try {
+      if (props.backNavQueryData) {
+        const queryString = atob(props.backNavQueryData);
+        query = JSON.parse(queryString);
+      }
+    } catch(error) {
+      console.error(error);
+    }
+    return { name: 'transaction-detail', query }
+  }
   return '/transaction/list'
 })
 

--- a/src/pages/transactions/TransactionSummary.vue
+++ b/src/pages/transactions/TransactionSummary.vue
@@ -174,17 +174,12 @@ const darkMode = computed(() => $store.getters['darkmode/getStatus'])
 
 const props = defineProps({
   txid: String,
-  assetIds: String,
   from: String,
 })
 
 const walletHash = computed(() => {
   if ($route.params.walletHash) return $route.params.walletHash
   return $store.getters['global/getWallet']('bch')?.walletHash
-})
-const parsedAssetIds = computed(() => {
-  if (typeof props.assetIds !== 'string') return ['bch'];
-  return props.assetIds.split(',');
 })
 
 const loadError = ref('')
@@ -299,43 +294,24 @@ async function fetchAllHistories () {
     return
   }
 
-  if (!parsedAssetIds.value || parsedAssetIds.value.length === 0) {
-    loadError.value = 'No asset IDs provided'
-    isLoading.value = false
-    return
-  }
-
   isLoading.value = true
   loadError.value = ''
 
   try {
     const baseUrl = getWatchtowerApiUrl()
-    const fetchPromises = parsedAssetIds.value.map(async (assetId) => {
-      const category = extractCategoryFromAssetId(assetId)
-      const categoryPath = category ? `/${category}` : ''
-      const url = `${baseUrl}/history/wallet/${encodeURIComponent(walletHash.value)}${categoryPath}/`
-      const response = await axios.get(url, { params: { txids: props.txid } })
-      
-      const data = response?.data?.history || response?.data || []
-      if (Array.isArray(data)) {
-        return data.map(item => ({
-          ...item,
-          _assetId: assetId
-        }))
-      }
-      return []
-    })
-
-    const results = await Promise.all(fetchPromises)
-    const allHistories = results.flat()
-    
+    const params = { all: true, txids: props.txid };
+    const url = `${baseUrl}/history/wallet/${encodeURIComponent(walletHash.value)}/`
+    const response = await axios.get(url, { params });
+    const data = response?.data?.history || response?.data || []
     const enrichedHistories = await Promise.all(
-      allHistories.map(async (history) => {
-        await attachAssetToHistory(history)
+      data.map(async (history) => {
+        let assetId = history?.token?.asset_id;
+        if (assetId === 'ct/1') assetId = 'bch';
+        history._assetId = assetId
+        await attachAssetToHistory(history);
         return history
       })
     )
-
     histories.value = enrichedHistories
     isLoading.value = false
     retryCount.value = 0
@@ -435,7 +411,7 @@ function viewAssetDetail (history) {
   const assetId = history.asset?.id || ''
   const txid = transactionId.value
 
-  let query = { from: 'summary', summaryAssetIds: props.assetIds }
+  let query = { from: 'summary' }
 
   
   if (assetId && assetId !== 'bch') {


### PR DESCRIPTION
## Description
- Improved wallet history fetching of wallet history in transaction summary to no longer require a list of assetIDs. Reduce api calls to a single api request that fetches all wallet history of all assets of the same provided txid.
- Added a button in transaction detail to navigate to transaction summary if the provided txid & wallet history has multiple wallet histories (e.g. cauldron trade and/or send transactions).


## Screenshots (if applicable):
<img width="450" height="900" alt="localhost_9000_(Realme 8) (6)" src="https://github.com/user-attachments/assets/4caddb44-9c7a-43a9-8afd-3663c60ef6cc" />


## Type of Change
- [x] UI improvements with no business logic changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Opened a transaction related to a cauldron trade. A button should display that navigates to transaction summary.

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
