### PR TITLE
fix(tx-detail): network fee missing when navigating from send page; confetti/audio playing twice

### DIFF
--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -466,6 +466,7 @@ export default {
       keypair: null,
       usingWebsocketData: false, // Track if we're using websocket data as fallback
       backgroundFetchActive: false, // Track if background fetch is active
+      newTxEffectsPlayed: false, // Track if confetti/audio has been played for this new tx
       displayRawAttributes: false,
       favorites: [],
       addingToFavorites: false,
@@ -992,6 +993,9 @@ export default {
           this.waitForRenderAndLaunchConfetti()
         }
       })
+      // Fetch complete transaction data from API in background
+      // to populate fields missing from the preloaded object (e.g. tx_fee)
+      this.startBackgroundFetch()
       return
     }
 
@@ -2844,6 +2848,10 @@ export default {
       })
     },
     async launchConfetti () {
+      // Only play confetti and audio once per transaction
+      if (this.newTxEffectsPlayed) return
+      this.newTxEffectsPlayed = true
+
       // Play sound for new transaction (non-blocking - don't wait for it)
       // Ensure audio is ready by waiting for next frame (allows preload to complete)
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Problem

1. **Network fee not displayed**: When the send page redirects to the transaction detail page after a successful send, the network fee does not show up — even on page reload. The fee only appears when the URL is opened directly in a new tab.

2. **Confetti and audio played twice**: Related side-effect causing duplicate celebration effects.

## Root Cause

The send page (`send.vue`) passes a minimal transaction object via `window.history.state` when navigating to the transaction detail page. This object is missing the `tx_fee` field.

In `TransactionDetail.vue`'s `mounted()` hook, when preloaded data is detected in `window.history.state.tx`, the component uses it directly and **returns early**, completely skipping the `fetchAndShow()` API call that would return the full transaction data including `tx_fee`.

- **Navigating from send page**: preloaded data exists → uses it as-is → no API call → `tx_fee` is `undefined` → fee hidden
- **Opening in new tab**: `window.history.state` is `null` → falls through to `fetchAndShow()` → API returns complete data with `tx_fee` → fee displayed

## Fix

1. **Background fetch for complete data** (`TransactionDetail.vue:999`): Even when preloaded data is available, call `startBackgroundFetch()` to fetch complete transaction data from the API in the background. This replaces the minimal preloaded object with the full API response, populating missing fields like `tx_fee`. The existing `startBackgroundFetch` mechanism already handles this pattern for websocket fallback data.

2. **Guard confetti/audio playback** (`TransactionDetail.vue:2848`): Added a `newTxEffectsPlayed` flag to `launchConfetti()` so confetti and sound only fire once, preventing duplicate effects when the background fetch updates the transaction data.

## Testing

- Navigate from send page after a successful transaction → network fee should appear (may take a moment as background fetch completes)
- Confetti and celebration audio should play exactly once
- Direct URL access still works as before