### PR TITLE
feat: highlight invalid seed phrase words during import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,8 @@
         "@walletconnect/client": "^1.8.0",
         "@walletconnect/core": "^2.22.4",
         "@walletconnect/utils": "^2.22.4",
-        "@wizardconnect/core": "^0.1.13",
-        "@wizardconnect/wallet": "^0.1.10",
+        "@wizardconnect/core": "^0.2.0",
+        "@wizardconnect/wallet": "^0.2.0",
         "aes256": "^1.1.0",
         "autoprefixer": "^10.4.20",
         "axios": "^0.21.4",
@@ -9244,9 +9244,9 @@
       }
     },
     "node_modules/@wizardconnect/core": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@wizardconnect/core/-/core-0.1.13.tgz",
-      "integrity": "sha512-xPmZ9EH/Nh/BzX2gs3raX7bcTInmPkyRSvNl2ABfsSjOuDN7LKKdI5D7u2XrO6iUpKRmtFMOqEYeHimpoZKDDw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@wizardconnect/core/-/core-0.2.3.tgz",
+      "integrity": "sha512-mOWgnKDOsI8w4QHIemRh9F/KhbuCNRxlnWeuFM/bSVVXHpJjjC5m91RYXNTnnMe+j5VgaH0r1fd2/gVG/WgB7Q==",
       "dependencies": {
         "@bch-wc2/interfaces": "^0.0.8",
         "@bitauth/libauth": "^3.1.0-next.2",
@@ -9297,9 +9297,9 @@
       }
     },
     "node_modules/@wizardconnect/wallet": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@wizardconnect/wallet/-/wallet-0.1.10.tgz",
-      "integrity": "sha512-mQ0/eRwQMl2n2c0mbzKhm7ArEBLOqqzaLK9GQwL1SaqJ8QziOn8ypPTqiMLHUAgto57vIu6FSLsV45aWeCR1cA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@wizardconnect/wallet/-/wallet-0.2.2.tgz",
+      "integrity": "sha512-mP8xBSnzEDc2VKPQ2tWQfqXBCiyxL244VNhOYLAm3fXewPvs0mW18aPkfjjt9Cqca25/VeKLRtP37TzpG/t12A==",
       "dependencies": {
         "@bitauth/libauth": "^3.1.0-next.2",
         "@wizardconnect/core": "*",

--- a/src/components/SeedPhraseContainer.vue
+++ b/src/components/SeedPhraseContainer.vue
@@ -39,9 +39,12 @@
             <q-input
               dense
               class="q-mt-sm bg-grey-3 q-px-md q-py-xs"
+              :class="{ 'word-invalid': isWordInvalid(index - 1) }"
+              :input-style="isWordInvalid(index - 1) ? 'color: #ffffff !important' : ''"
               style="border-radius: 10px;"
               v-model="inputArray[index - 1]"
-              @update:model-value="onInputEnter(index)"
+              @update:model-value="onInputChange(index)"
+              @blur="onInputBlur(index)"
               :dark="darkMode"
             />
           </div>
@@ -65,6 +68,10 @@ export default {
     isImport: {
       type: Boolean,
       default: false
+    },
+    invalidWords: {
+      type: Array,
+      default: () => []
     }
   },
 
@@ -77,7 +84,8 @@ export default {
       inputArray: Array(12).fill(''),
       animationStarted: false,
       showReplayButton: false,
-      animationTimeout: null
+      animationTimeout: null,
+      validationDebounce: null
     }
   },
 
@@ -89,8 +97,22 @@ export default {
 
   methods: {
     getDarkModeClass,
-    onInputEnter (index) {
+    isWordInvalid (index) {
+      return this.invalidWords.includes(index) && this.inputArray[index]
+    },
+    onInputChange (index) {
       this.inputArray[index - 1] = this.cleanUpSeedPhrase(this.inputArray[index - 1])
+      const wordIndex = index - 1
+      // Debounce validation for last word or when correcting an invalid word
+      if (index === 12 || this.invalidWords.includes(wordIndex)) {
+        if (this.validationDebounce) clearTimeout(this.validationDebounce)
+        this.validationDebounce = setTimeout(() => {
+          this.$emit('on-input-enter', this.inputArray)
+        }, 400)
+      }
+    },
+    onInputBlur (index) {
+      if (this.validationDebounce) clearTimeout(this.validationDebounce)
       this.$emit('on-input-enter', this.inputArray)
     },
     cleanUpSeedPhrase (seedPhrase) {
@@ -178,6 +200,9 @@ export default {
     // Clean up timeout when component is destroyed
     if (this.animationTimeout) {
       clearTimeout(this.animationTimeout)
+    }
+    if (this.validationDebounce) {
+      clearTimeout(this.validationDebounce)
     }
   }
 }
@@ -308,5 +333,10 @@ export default {
     pre {
       margin: 10px 0;
     }
+  }
+
+  :deep(.word-invalid) {
+    background: rgba(255, 0, 0, 0.15) !important;
+    border: 1px solid #ff4444 !important;
   }
 </style>

--- a/src/pages/registration/accounts.vue
+++ b/src/pages/registration/accounts.vue
@@ -404,7 +404,7 @@
                     @click="useTextArea = true, seedPhraseBackup = ''"
                   />
                 </div>
-                <SeedPhraseContainer :isImport="true" @on-input-enter="onInputEnter" />
+                <SeedPhraseContainer :isImport="true" :invalidWords="invalidWordIndices" @on-input-enter="onInputEnter" />
             </div>
               </template>
         </div>
@@ -588,6 +588,8 @@
 import { Wallet, storeMnemonic, generateMnemonic, computeWalletHash } from '../../wallet'
 import { getMnemonic } from '../../wallet'
 import { utils } from 'ethers'
+import { wordlists } from 'bip39'
+const EN_WORDLIST = wordlists.EN
 import { Device } from '@capacitor/device'
 import { NativeBiometric } from 'capacitor-native-biometric'
 import { getDarkModeClass, isHongKong } from 'src/utils/theme-darkmode-utils'
@@ -656,6 +658,7 @@ export default {
       serverOnline: null,
       importSeedPhrase: false,
       seedPhraseBackup: null,
+      invalidWordIndices: [],
       mnemonic: '',
       newWalletHash: '',
       newWalletSnapshot: {
@@ -871,6 +874,16 @@ export default {
       } else {
         return false
       }
+    },
+    getInvalidWordIndices (inputArray) {
+      const invalidIndices = []
+      for (let i = 0; i < inputArray.length; i++) {
+        const word = inputArray[i]?.toLowerCase().trim()
+        if (word && !EN_WORDLIST.includes(word)) {
+          invalidIndices.push(i)
+        }
+      }
+      return invalidIndices
     },
     cleanUpSeedPhrase (seedPhrase) {
       return seedPhrase.toLowerCase().trim()
@@ -2234,6 +2247,7 @@ export default {
       if (inputArray.indexOf('') === -1) {
         this.seedPhraseBackup = inputArray.join(' ')
       }
+      this.invalidWordIndices = this.getInvalidWordIndices(inputArray)
     },
     async promptEnablePushNotification() {
       await this.$pushNotifications.isPushNotificationEnabled().catch(console.log)


### PR DESCRIPTION
## Summary
Improves the seed phrase import experience by validating each word against the BIP39 wordlist and providing clear visual feedback when a word is incorrect.

## Problem
Previously, when importing a seed phrase, users only saw a generic \"Invalid seed phrase\" error after submitting all 12 words. There was no way to know which specific word was misspelled or not in the BIP39 dictionary, making correction tedious trial-and-error.

## Solution
- **Per-word validation**: Each word is checked against the official BIP39 English wordlist (`bip39` package).
- **Visual feedback**: Invalid words are highlighted with:
  - Light red background (`rgba(255, 0, 0, 0.15)`)
  - Red border (`#ff4444`)
  - White text for readability against the red background
- **Empty inputs**: Keep default styling (no highlight on empty fields)
- **Smart validation timing**:
  - **Blur/unfocus**: Validates immediately when leaving an input
  - **Correcting an invalid word**: Debounced validation (400ms) — gives time to finish typing before removing the highlight
  - **Last word (12th)**: Also debounced at 400ms — allows finishing the full phrase before validating

## Files Changed
- `src/pages/registration/accounts.vue`
  - Import BIP39 wordlist
  - Add `getInvalidWordIndices()` to identify words not in the dictionary
  - Track `invalidWordIndices` state
  - Pass invalid indices to `SeedPhraseContainer`

- `src/components/SeedPhraseContainer.vue`
  - Accept `invalidWords` prop
  - Apply conditional styling on invalid inputs
  - Handle `@blur` for immediate validation
  - Handle `@update:model-value` with debounce for smooth UX while correcting
  - Debounce last word validation for natural typing flow

## Testing
1. Go to Restore Wallet → Import Seed Phrase
2. Enter a word not in the BIP39 list (e.g., \"xyzzy\") in any field
3. Blur the field — it should highlight red
4. Start correcting it — highlight should stay until you stop typing for 400ms
5. Enter the 12th word — validation happens after 400ms debounce
6. Leave any field empty — no red highlight