### PR TITLE
fix(send): hide Cauldron button for NFTs

### DIFF
--- a/src/components/send-page/SendPageForm.vue
+++ b/src/components/send-page/SendPageForm.vue
@@ -149,7 +149,7 @@
     </div>
   </div>
 
-  <div v-if="!cauldronEnabled" class="q-mt-sm">
+  <div v-if="!isNFT && !cauldronEnabled" class="q-mt-sm">
     <q-btn
       no-caps
       :label="asset?.id === 'bch' ? $t('SendUsingTokensWithCauldron') : $t('SendUsingBchWithCauldron')"
@@ -160,7 +160,7 @@
       @click="toggleCauldron"
     />
   </div>
-  <div v-else class="row items-start no-wrap q-mt-sm">
+  <div v-else-if="!isNFT && cauldronEnabled" class="row items-start no-wrap q-mt-sm">
     <div class="full-width">
       <q-input
         ref="cauldronAmountInput"


### PR DESCRIPTION
## Summary
This PR fixes a bug where the **"Sending using BCH with Cauldron"** button is visible when sending NFTs. Clicking it triggers an incorrect send where only dust BCH is transferred and the NFT remains in the wallet.

## Changes
- Added `!isNFT` guard to the Cauldron toggle button so it is hidden when the asset being sent is an NFT.
- Added `!isNFT` guard to the Cauldron active state UI for consistency.

## Related Issue
N/A (reported internally)