### PR TITLE
Create hydrateContract to recognise contract used as output source fo…

### DIFF
--- a/src/wallet/wizardconnect/service.js
+++ b/src/wallet/wizardconnect/service.js
@@ -202,6 +202,7 @@ function hydrateSourceOutput(so) {
     lockingBytecode: toUint8Array(so.lockingBytecode),
     ...(hasUnlocking && { unlockingBytecode: toUint8Array(so.unlockingBytecode) }),
     ...(so.token && { token: hydrateToken(so.token) }),
+    ...(so.contract && { contract: hydrateContract(so.contract) }),
   }
 }
 
@@ -217,6 +218,15 @@ function hydrateNft(nft) {
   return {
     ...(nft.capability !== undefined && { capability: nft.capability }),
     ...(nft.commitment !== undefined && { commitment: toUint8Array(nft.commitment) }),
+  }
+}
+
+function hydrateContract(contract) {
+  if (!contract) return undefined
+  return {
+    ...(contract.abiFunction && { abiFunction: contract.abiFunction }),
+    ...(contract.redeemScript !== undefined && { redeemScript: toUint8Array(contract.redeemScript) }),
+    ...(contract.artifact && { artifact: contract.artifact }),
   }
 }
 

--- a/src/wallet/wizardconnect/service.js
+++ b/src/wallet/wizardconnect/service.js
@@ -221,13 +221,43 @@ function hydrateNft(nft) {
   }
 }
 
+/**
+ * Hydrate a raw contract field from a sign request source output.
+ *
+ * Part of WcSignTransactionRequest (@bch-wc2/interfaces), carried inside the
+ * WizardConnect sign_transaction_request message.
+ * Protocol: https://gitlab.com/riftenlabs/lib/wizardconnect/-/blob/master/docs/protocol.md
+ *
+ * Present on source outputs that are contract UTXOs (e.g. a Cauldron pool) rather
+ * than plain P2PKH outputs. The libauth transaction compiler needs all three fields
+ * to reconstruct and sign contract input, a partial or invalid object throws.
+ * Returns undefined when absent so callers can spread the result conditionally.
+ *
+ * abiFunction: { name: string, inputs: AbiInput[] } is passed through as-is.
+ * redeemScript: hex string or Uint8Array (extended JSON `<Uint8Array: 0x...>` also accepted).
+ * artifact: plain object is passed through as-is.
+ */
 function hydrateContract(contract) {
   if (!contract) return undefined
-  return {
-    ...(contract.abiFunction && { abiFunction: contract.abiFunction }),
-    ...(contract.redeemScript !== undefined && { redeemScript: toUint8Array(contract.redeemScript) }),
-    ...(contract.artifact && { artifact: contract.artifact }),
+  if (typeof contract !== 'object' || Array.isArray(contract)) {
+    throw new Error(`hydrateContract: expected plain object, got ${Array.isArray(contract) ? 'array' : typeof contract}`)
   }
+
+  const { abiFunction, redeemScript, artifact } = contract
+
+  if (typeof abiFunction !== 'object' || Array.isArray(abiFunction) || abiFunction === null || typeof abiFunction.name !== 'string' || !abiFunction.name.trim()) {
+    throw new Error(`hydrateContract: abiFunction must be an object with a non-empty name string`)
+  }
+  if ((typeof redeemScript !== 'string' && !(redeemScript instanceof Uint8Array)) || redeemScript.length === 0) {
+    throw new Error(`hydrateContract: redeemScript must be a non-empty string or Uint8Array, got ${
+      typeof redeemScript === 'string' || redeemScript instanceof Uint8Array ? 'empty' : typeof redeemScript
+    }`)
+  }
+  if (typeof artifact !== 'object' || Array.isArray(artifact) || artifact === null) {
+    throw new Error(`hydrateContract: artifact must be a plain object`)
+  }
+
+  return { abiFunction, redeemScript: toUint8Array(redeemScript), artifact }
 }
 
 /**


### PR DESCRIPTION
Create hydrateContract to recognise contract used as output source for transaction such as pool withdraw

## Description
hydrateSourceOutput was not forwarding the contract field from WizardConnect source outputs. For P2SH32 inputs such as Cauldron liquidity pools, the dapp includes a contract object containing the redeemScript (needed to compute the signature hash), the artifact (used by signBchTransaction to detect a contract input), and the abiFunction (function signature for display). Without it, signBchTransaction fell through to the P2PKH path, left the unlocking bytecode empty, and the node rejected the transaction with:

mandatory-script-verify-flag-failed (Operation not valid with the current stack size)

Fixes # (issue)

Adds hydrateContract following the same pattern as hydrateToken and hydrateNft, deserializing redeemScript from its extended JSON wire format to Uint8Array and passing abiFunction and artifact through unchanged.   

## Screenshots (if applicable):

Before:

<img width="838" height="301" alt="Screenshot 2026-05-04 at 15 09 56" src="https://github.com/user-attachments/assets/fa6f2321-0d96-4f7c-b08b-a5f2d838d28c" />

After:

<img width="316" height="282" alt="Screenshot 2026-05-04 at 15 10 44" src="https://github.com/user-attachments/assets/02472852-67e3-4344-b215-22ef661888b0" />

## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Manually tested by initiating a Cauldron liquidity pool withdrawal from cauldron.quest with a WizardConnect-connected wallet. Before this fix the transaction was rejected by the network. After this fix it broadcasts and confirms successfully.                                                                                                                                                                    
                                                                                                                                                                                            
Run with: npm run dev (quasar SPA)                                                                                                                                                        
                                                            
No other areas of the code are affected. hydrateSourceOutput is only called within signRequest in this file, and the change is purely additive.

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
