### PR TITLE
Fix/cauldron trade

### DIFF
--- a/src/pages/apps/cauldron/trade.vue
+++ b/src/pages/apps/cauldron/trade.vue
@@ -860,7 +860,7 @@ export default defineComponent({
     const bchBalanceSats = computed(() => {
       const assets = $store.getters['assets/getAssets'];
       const bchAsset = assets?.find(asset => asset?.id === 'bch');
-      const bchBalanceSats = BigInt(Math.floor(Number(bchAsset?.balance || 0) * 10 ** 8));
+      const bchBalanceSats = BigInt(Math.floor(Number(bchAsset?.spendable || 0) * 10 ** 8));
       return bchBalanceSats;
     })
 
@@ -868,7 +868,7 @@ export default defineComponent({
     async function updateBalance() {
       const { bchWallet } = await loadWalletForTrade();
       const bchBalanceFetch = bchWallet.getBalance().then(response => {
-        $store.commit('assets/updateAssetBalance', { id: 'bch', balance: response.balance })
+        $store.commit('assets/updateAssetBalance', { id: 'bch', balance: response.balance, spendable: response.spendable })
       })
 
       const tokenId = selectedToken.value?.token_id

--- a/src/pages/apps/cauldron/trade.vue
+++ b/src/pages/apps/cauldron/trade.vue
@@ -397,6 +397,8 @@ export default defineComponent({
     const $q = useQuasar();
     const $store = useStore();
     const darkMode = computed(() => $store.getters['darkmode/getStatus']);
+    const exlab = new ExchangeLab();
+    exlab.setDefaultPreferredTokenOutputBCHAmount(1000n);
     
     // Wallet index for detecting wallet switches
     const walletIndex = computed(() => $store.getters['global/getWalletIndex']);
@@ -583,6 +585,7 @@ export default defineComponent({
           return;
         }
         let result = attemptTrade({
+          exlab,
           pools: poolV0List,
           isBuyingToken: isBuyingToken.value,
           demand: isSupplyMode.value ? 0n : amountInUnits.value,
@@ -591,11 +594,11 @@ export default defineComponent({
 
         if (!isSupplyMode.value && amountInUnits.value != result.summary.demand) {
           const adjustAmount = amountInUnits.value - result.summary.demand;
-          const adjustedTradeResult = adjustDemand({ tradeResult: result, amount: adjustAmount });
+          const adjustedTradeResult = adjustDemand({ exlab, tradeResult: result, amount: adjustAmount });
           if (adjustedTradeResult) result = adjustedTradeResult;
         } else if (isSupplyMode.value && result.summary.supply != amountInUnits.value) {
           const adjustAmount = amountInUnits.value - result.summary.supply;
-          const adjustedTradeResult = adjustSupply({ tradeResult: result, amount: adjustAmount });
+          const adjustedTradeResult = adjustSupply({ exlab, tradeResult: result, amount: adjustAmount });
           if (adjustedTradeResult) result = adjustedTradeResult;
         }
 
@@ -968,6 +971,7 @@ export default defineComponent({
       }
 
       const tradeResult = attemptTrade({
+        exlab,
         pools: poolV0List,
         isBuyingToken: isBuyingToken.value,
         supply: baseSupply,
@@ -1076,7 +1080,6 @@ export default defineComponent({
           platformFee: _platformFee
         })
 
-        const exlab = new ExchangeLab()
         const txFeePerByte = 1n;
         const tradeTxBuildResult = exlab.createTradeTx(
           _tradeResult.entries,

--- a/src/wallet/cauldron/send.ts
+++ b/src/wallet/cauldron/send.ts
@@ -7,6 +7,7 @@ import { attemptTrade } from "./transact";
 import { type CauldronTokenData } from "./tokens";
 import { TransactionBalancer } from "../stablehedge/transaction-utils";
 import BchWallet from "../bch";
+import { poolTradeToCashscriptOutput } from "./utils";
 import { getInputSize, getOutputSize } from "cashscript/dist/utils";
 import { LibauthHDWallet } from "../bch-libauth";
 import { getChangeAddress } from "src/utils/send-page-utils";
@@ -542,24 +543,6 @@ function poolTradeToCashscriptUtxoAndOutput(poolTrade: PoolTrade) {
   const output = poolTradeToCashscriptOutput(poolTrade);
 
   return { utxo, output };
-}
-
-function poolTradeToCashscriptOutput(poolTrade: PoolTrade): Output {
-  // Calculate how much satoshis or token is added or deducted
-  const isSupplyingBch = poolTrade.supply_token_id == NATIVE_BCH_TOKEN_ID;
-  const satoshisDelta = isSupplyingBch ? poolTrade.supply : poolTrade.demand * -1n;
-  const tokenDelta = isSupplyingBch ? poolTrade.demand * -1n : poolTrade.supply;
-
-  const poolOutput = poolTrade.pool.output;
-  return {
-    to: poolOutput.locking_bytecode,
-    amount: poolOutput.amount + satoshisDelta,
-    token: {
-      amount: poolOutput.token.amount + tokenDelta,
-      category: poolOutput.token.token_id,
-    }
-  };
-
 }
 
 function normalizeRecipients(asset:AssetData, recipients: RecipientData[], inputExtras: InputExtra[]): NormalizedRecipient[] {

--- a/src/wallet/cauldron/transact.js
+++ b/src/wallet/cauldron/transact.js
@@ -280,15 +280,16 @@ export function createInputAndOutput(opts) {
     if (remainingSats <= 0n) break
     inputCoins.push(spendableCoin)
     remainingSats -= spendableCoin.output.amount;
+    remainingSats += P2PKH_INPUT_SIZE;
   }
 
-  if (remainingSats < -546n || remainingTokens < 0n) {
-    payouts.push({
-      type: PayoutAmountRuleType.CHANGE,
-      locking_bytecode: lockingBytecode,
-      allow_mixing_native_and_token: false,
-    })
-  }
+  payouts.push({
+    type: PayoutAmountRuleType.CHANGE,
+    locking_bytecode: lockingBytecode,
+    allow_mixing_native_and_token: false,
+    allow_mixing_native_and_token_when_bch_change_is_dust: false,
+    add_change_to_txfee_when_bch_change_is_dust: true,
+  })
 
   return { inputCoins, payouts }
 }

--- a/src/wallet/cauldron/transact.js
+++ b/src/wallet/cauldron/transact.js
@@ -372,7 +372,8 @@ export function testTradeResult(opts) {
     type: 'CHANGE',
     locking_bytecode: lockingBytecode,
     allow_mixing_native_and_token: false,
-    allow_mixing_native_and_token_when_bch_change_is_dust: true,
+    allow_mixing_native_and_token_when_bch_change_is_dust: false,
+    add_change_to_txfee_when_bch_change_is_dust: true,
   })
 
   const tradeTx = exlab.createTradeTx(tradeResult.entries, coins, payoutRules, null, 1n)

--- a/src/wallet/cauldron/transact.js
+++ b/src/wallet/cauldron/transact.js
@@ -1,9 +1,10 @@
 import { ExchangeLab } from "@cashlab/cauldron";
 import { NATIVE_BCH_TOKEN_ID, PayoutAmountRuleType } from '@cashlab/common';
-import { cashAddressToLockingBytecode, generateRandomBytes, privateKeyToP2pkhLockingBytecode, addressContentsToLockingBytecode } from "@cashlab/common/libauth.js";
+import { cashAddressToLockingBytecode, generateRandomBytes, privateKeyToP2pkhLockingBytecode, addressContentsToLockingBytecode, bigIntToCompactUint, compactUintPrefixToLength } from "@cashlab/common/libauth.js";
 import { buildPoolV0UnlockingBytecode } from '@cashlab/cauldron';
 import { getInputSize, getOutputSize } from 'cashscript/dist/utils.js';
 import { calcTradeSummary, calcTradeWithTargetDemandFromAPair, calcTradeWithTargetSupplyFromAPair } from "@cashlab/cauldron/util.js";
+import { poolTradeToCashscriptOutput } from "./utils";
 
 const PLACEHOLDER_TOKEN_ID_FOR_SIZE_CALC = Array.from({ length: 64 }).fill('0').join('');
 
@@ -183,10 +184,12 @@ const P2PKH_INPUT_SIZE = 141n;
  * @param {{ to:String, amount:BigInt }} opts.platformFee
  * @param {import("@cashlab/cauldron").TradeResult} opts.tradeResult
  * @param {import('@cashlab/common').SpendableCoin[]} opts.spendableCoins
+ * @param {bigint} [opts.tokenOutputSats]
  */
 export function createInputAndOutput(opts) {
   const tradeResult = opts?.tradeResult
   const spendableCoins = opts?.spendableCoins
+  const tokenOutputSats = opts?.tokenOutputSats ?? 1000n;
 
   const privateKey = spendableCoins[0].key
   const lockingBytecode = privateKeyToP2pkhLockingBytecode({ privateKey, throwErrors: true })
@@ -227,7 +230,7 @@ export function createInputAndOutput(opts) {
     if (remainingTokens < 0n) {
       const changeTokenOutput = {
         to: lockingBytecode,
-        amount: 1000n,
+        amount: tokenOutputSats,
         token: {category: PLACEHOLDER_TOKEN_ID_FOR_SIZE_CALC, amount: remainingTokens * -1n },
       }
       satoshisToSupply += changeTokenOutput.amount
@@ -238,21 +241,22 @@ export function createInputAndOutput(opts) {
     payouts.push({
       type: PayoutAmountRuleType.FIXED,
       locking_bytecode: lockingBytecode,
-      amount: 1000n,
+      amount: tokenOutputSats,
       token: {
         token_id: tradeResult.entries[0].demand_token_id,
         amount: tradeResult.summary.demand,
       }
     })
-    satoshisToSupply += 1000n + 25n
-  }
 
-
-  let remainingSats = satoshisToSupply
-  for(const spendableCoin of bchCoins) {
-    if (remainingSats <= 0n) break
-    inputCoins.push(spendableCoin)
-    remainingSats -= spendableCoin.output.amount;
+    const outputSize = getOutputSize({
+      to: lockingBytecode,
+      amount: tokenOutputSats,
+      token: {
+        category: tradeResult.entries[0].demand_token_id,
+        amount: tradeResult.summary.demand,
+      }
+    })
+    satoshisToSupply += tokenOutputSats + BigInt(outputSize);
   }
 
   if (opts?.platformFee) {
@@ -261,6 +265,21 @@ export function createInputAndOutput(opts) {
       locking_bytecode: cashAddressToLockingBytecode(opts?.platformFee?.to)?.bytecode,
       amount: opts.platformFee.amount,
     })
+    const outputSize = getOutputSize(opts.platformFee);
+    satoshisToSupply += opts.platformFee.amount + BigInt(outputSize);
+  }
+
+  // Following lines include the base tx fee in satoshis to supply
+  satoshisToSupply += 8n; // locktime + version size
+  const inputSizePrefixLength = compactUintPrefixToLength(bigIntToCompactUint(tradeResult.entries.length + inputCoins.length));
+  const outputSizePrefixLength = compactUintPrefixToLength(bigIntToCompactUint(tradeResult.entries.length + payouts.length));
+  satoshisToSupply += BigInt(inputSizePrefixLength) + BigInt(outputSizePrefixLength); // although this isnt final but its more accurate
+
+  let remainingSats = satoshisToSupply
+  for(const spendableCoin of bchCoins) {
+    if (remainingSats <= 0n) break
+    inputCoins.push(spendableCoin)
+    remainingSats -= spendableCoin.output.amount;
   }
 
   if (remainingSats < 0n || remainingTokens < 0n) {
@@ -280,8 +299,6 @@ export function createInputAndOutput(opts) {
  * @param {import('@cashlab/cauldron').TradeResult} tradeResult 
  */
 export function getEntriesSize(tradeResult) {
-  const isBuyingToken = tradeResult.entries[0].supply_token_id == NATIVE_BCH_TOKEN_ID
-
   const inputFees = tradeResult.entries
     .map(entry => buildPoolV0UnlockingBytecode(entry.pool.parameters))
     .map(unlockingBytecode => getInputSize(unlockingBytecode))
@@ -289,15 +306,8 @@ export function getEntriesSize(tradeResult) {
 
   const outputFees = tradeResult.entries
     .map(entry => {
-      const category = isBuyingToken ? entry.demand_token_id : entry.supply_token_id
-      return getOutputSize({
-        to: entry.pool.output.locking_bytecode,
-        amount: isBuyingToken ? entry.supply : entry.demand,
-        token: {
-          category: category,
-          amount: isBuyingToken ? entry.demand : entry.supply
-        }
-      })
+      const output = poolTradeToCashscriptOutput(entry);
+      return getOutputSize(output);
     })
     .reduce((subtotal, size) => subtotal + size, 0)
 

--- a/src/wallet/cauldron/transact.js
+++ b/src/wallet/cauldron/transact.js
@@ -282,12 +282,11 @@ export function createInputAndOutput(opts) {
     remainingSats -= spendableCoin.output.amount;
   }
 
-  if (remainingSats < 0n || remainingTokens < 0n) {
+  if (remainingSats < -546n || remainingTokens < 0n) {
     payouts.push({
       type: PayoutAmountRuleType.CHANGE,
       locking_bytecode: lockingBytecode,
       allow_mixing_native_and_token: false,
-      allow_mixing_native_and_token_when_bch_change_is_dust: true,
     })
   }
 

--- a/src/wallet/cauldron/utils.js
+++ b/src/wallet/cauldron/utils.js
@@ -1,5 +1,5 @@
 import { ExchangeLab } from '@cashlab/cauldron';
-import { SpendableCoinType } from '@cashlab/common';
+import { SpendableCoinType, NATIVE_BCH_TOKEN_ID } from '@cashlab/common';
 import { privateKeyToP2pkhLockingBytecode } from '@cashlab/common/libauth.js';
 import { decodePrivateKeyWif, hexToBin } from '@bitauth/libauth';
 import { i18n } from 'src/boot/i18n';
@@ -95,6 +95,29 @@ export function watchtowerUtxosToSpendableCoins(opts) {
       },
     }
   })
+}
+
+/**
+ * 
+ * Used to be in send.ts but moved here since used by other functions outside send.ts
+ * @param {import("@cashlab/cauldron").PoolTrade} poolTrade 
+ * @returns {import("cashscript").Output}
+ */
+export function poolTradeToCashscriptOutput(poolTrade) {
+  // Calculate how much satoshis or token is added or deducted
+  const isSupplyingBch = poolTrade.supply_token_id == NATIVE_BCH_TOKEN_ID;
+  const satoshisDelta = isSupplyingBch ? poolTrade.supply : poolTrade.demand * -1n;
+  const tokenDelta = isSupplyingBch ? poolTrade.demand * -1n : poolTrade.supply;
+
+  const poolOutput = poolTrade.pool.output;
+  return {
+    to: poolOutput.locking_bytecode,
+    amount: poolOutput.amount + satoshisDelta,
+    token: {
+      amount: poolOutput.token.amount + tokenDelta,
+      category: poolOutput.token.token_id,
+    }
+  };
 }
 
 export function parseCauldronSwapAttribute(value='') {


### PR DESCRIPTION
## Description
- Fix error showing not enough tokens in payout during cauldron trade.
  - Improved calculation of required satoshis when selecting UTXOs for cauldron trade.
  - Removed `allow_mixing_native_and_token_when_bch_change_is_dust` flag for change output payout due to `@cashlab/common` internal bug where payouts are recalculated without proper resetting of some variables.
  - Added `add_change_to_txfee_when_bch_change_is_dust` flag for skipping adding change output.
- Other: Use spendable BCH balance when displaying balance & calculating max tradeable amount

Fixes # (issue)


## Screenshots (if applicable):
<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/ad07f37d-9ed8-4c9a-9ba7-f440c6adda4d" />


## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
The bug happens on cases where the change sats is less than dust amount.  Usually equal or slightly above value displayed in MAX button.
