### PR TITLE
Small modification on how wizardconnect handle broadcast option on a sign request 

### DIFF
--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -213,7 +213,7 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     const isChipnet = rootGetters['global/isChipnet'] || false
     const watchtower = new Watchtower(isChipnet)
 
-    if (request.transaction.broadcast === true) {
+    if (request.transaction?.broadcast === true) {
       watchtower.BCH.broadcastTransaction(signedTxHex).catch(err => {
         console.log('WizardConnect: wallet-side broadcast (redundant) failed or tx already known:', err)
       })

--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -209,7 +209,6 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     const request = JSON.parse(transactionJson)
     const signedTxHex = await wizardConnectService.signRequest(request)
 
-    // Fire-and-forget broadcast via watchtower (redundant to dApp broadcast)
     const isChipnet = rootGetters['global/isChipnet'] || false
     const watchtower = new Watchtower(isChipnet)
 

--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -212,10 +212,13 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     // Fire-and-forget broadcast via watchtower (redundant to dApp broadcast)
     const isChipnet = rootGetters['global/isChipnet'] || false
     const watchtower = new Watchtower(isChipnet)
-    watchtower.BCH.broadcastTransaction(signedTxHex).catch(err => {
-      console.log('WizardConnect: wallet-side broadcast (redundant) failed or tx already known:', err)
-    })
 
+    if (request.broadcastTransaction === true) {
+      watchtower.BCH.broadcastTransaction(signedTxHex).catch(err => {
+        console.log('WizardConnect: wallet-side broadcast (redundant) failed or tx already known:', err)
+      })
+    }
+    
     await wizardConnectService.sendSignResponse(connectionId, sequence, signedTxHex)
     
     // After transaction, check buffer (delayed to allow backend to process)

--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -213,7 +213,7 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     const isChipnet = rootGetters['global/isChipnet'] || false
     const watchtower = new Watchtower(isChipnet)
 
-    if (request.broadcastTransaction === true) {
+    if (request.transaction.broadcast === true) {
       watchtower.BCH.broadcastTransaction(signedTxHex).catch(err => {
         console.log('WizardConnect: wallet-side broadcast (redundant) failed or tx already known:', err)
       })


### PR DESCRIPTION
## Description
Enforce the broadcast flag set by the SignRequest from dapp instead of forcing broadcast.

Fixes # (issue)
Unexpected broadcast error on dapp when broadcast is set to false

## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Applying the change now fixes the broadcast error on dapp if the dapp sets the broadcast flag to false.

## @mentions
@joemarct 
