### PR TITLE
feat: block native keyboard and show tooltip when custom keyboard is active

### DIFF
--- a/src/components/CustomInput.vue
+++ b/src/components/CustomInput.vue
@@ -21,9 +21,7 @@
     </template>
   </q-input>
 
-  <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
-    {{ $t('PleaseUseCustomKeyboard') }}
-  </div>
+  <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
   </div>
 
   <teleport to="body">
@@ -44,6 +42,8 @@ import {
 import { formatWithLocale } from 'src/utils/denomination-utils';
 
 import CustomKeyboard from './CustomKeyboard.vue';
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 
 export default {
   name: 'CustomInput',
@@ -73,7 +73,12 @@ export default {
   ],
 
   components: {
-    CustomKeyboard
+    CustomKeyboard,
+    KeyboardTooltip
+  },
+  setup() {
+    const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
+    return { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip }
   },
 
   data () {
@@ -82,9 +87,6 @@ export default {
       valFormatted: '',
       keyboardState: '',
       keyPressed: '',
-      keyboardTipTimer: null,
-      keyboardTipCounter: 0,
-      showKeyboardTooltip: false
     }
   },
 
@@ -126,14 +128,10 @@ export default {
   methods: {
     onKeyboardInput (e) {
       e.preventDefault()
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = true
-      this.keyboardTipCounter++
-      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
+      this.showKeyboardTooltip()
     },
     setAmount (key) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       const inputNativeEl = this.$refs.inputRef.nativeEl
       inputNativeEl.focus({ focusVisible: true })
 
@@ -146,8 +144,7 @@ export default {
       this.$emit('on-amount-click', this.val)
     },
     makeKeyAction (key) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       const inputNativeEl = this.$refs.inputRef.nativeEl
       this.keyPressed = String(key)
 
@@ -178,47 +175,4 @@ export default {
 </script>
 
 <style scoped>
-.keyboard-tooltip-bubble {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  bottom: calc(100% + 10px);
-  z-index: 10;
-  white-space: nowrap;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 13px;
-  line-height: 1.4;
-  font-weight: 700;
-  pointer-events: none;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-  animation: shake 0.4s ease-in-out;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 7px solid transparent;
-  }
-
-  &.dark {
-    background: #d32f2f;
-    color: #fff;
-    &::after { border-top-color: #d32f2f; }
-  }
-
-  &.light {
-    background: #e53935;
-    color: #fff;
-    &::after { border-top-color: #e53935; }
-  }
-}
-
-@keyframes shake {
-  0%, 100% { transform: translateX(-50%); }
-  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-}
 </style>

--- a/src/components/CustomInput.vue
+++ b/src/components/CustomInput.vue
@@ -6,6 +6,7 @@
     ref="inputRef"
     v-model="valFormatted"
     @focus="!disable && (keyboardState = 'show')"
+    @keydown="onKeyboardInput"
     :label="label || $t('Amount')"
     :dark="darkMode"
     :rules="inputRules"
@@ -18,6 +19,10 @@
       </div>
     </template>
   </q-input>
+
+  <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs q-ml-sm">
+    {{ $t('PleaseUseCustomKeyboard') }}
+  </div>
 
   <teleport to="body">
     <custom-keyboard
@@ -74,7 +79,8 @@ export default {
       val: this.modelValue != null ? String(this.modelValue) : '',
       valFormatted: '',
       keyboardState: '',
-      keyPressed: ''
+      keyPressed: '',
+      showKeyboardTooltip: false
     }
   },
 
@@ -114,7 +120,12 @@ export default {
   },
 
   methods: {
+    onKeyboardInput (e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
+    },
     setAmount (key) {
+      this.showKeyboardTooltip = false
       const inputNativeEl = this.$refs.inputRef.nativeEl
       inputNativeEl.focus({ focusVisible: true })
 
@@ -127,6 +138,7 @@ export default {
       this.$emit('on-amount-click', this.val)
     },
     makeKeyAction (key) {
+      this.showKeyboardTooltip = false
       const inputNativeEl = this.$refs.inputRef.nativeEl
       this.keyPressed = String(key)
 

--- a/src/components/CustomInput.vue
+++ b/src/components/CustomInput.vue
@@ -1,4 +1,5 @@
 <template>
+  <div style="position: relative;">
   <q-input
     filled
     type="text"
@@ -20,8 +21,9 @@
     </template>
   </q-input>
 
-  <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs q-ml-sm">
+  <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
     {{ $t('PleaseUseCustomKeyboard') }}
+  </div>
   </div>
 
   <teleport to="body">
@@ -80,6 +82,8 @@ export default {
       valFormatted: '',
       keyboardState: '',
       keyPressed: '',
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
       showKeyboardTooltip: false
     }
   },
@@ -122,9 +126,13 @@ export default {
   methods: {
     onKeyboardInput (e) {
       e.preventDefault()
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = true
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
     },
     setAmount (key) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       const inputNativeEl = this.$refs.inputRef.nativeEl
       inputNativeEl.focus({ focusVisible: true })
@@ -138,6 +146,7 @@ export default {
       this.$emit('on-amount-click', this.val)
     },
     makeKeyAction (key) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       const inputNativeEl = this.$refs.inputRef.nativeEl
       this.keyPressed = String(key)
@@ -167,3 +176,49 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.keyboard-tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(100% + 10px);
+  z-index: 10;
+  white-space: nowrap;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 700;
+  pointer-events: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  animation: shake 0.4s ease-in-out;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 7px solid transparent;
+  }
+
+  &.dark {
+    background: #d32f2f;
+    color: #fff;
+    &::after { border-top-color: #d32f2f; }
+  }
+
+  &.light {
+    background: #e53935;
+    color: #fff;
+    &::after { border-top-color: #e53935; }
+  }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(-50%); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
+}
+</style>

--- a/src/components/CustomKeyboardInput.vue
+++ b/src/components/CustomKeyboardInput.vue
@@ -7,8 +7,8 @@
         <CustomKeyboard
           :modelValue="ctx.modelValue"
           :customKeyboardState="ctx.focused ? 'show': ''"
-           @update:modelValue="val => { ctx.emitValue(val); clearTimeout(keyboardTipTimer); showKeyboardTooltip = false }"
-           @makeKeyAction="action => { if (action === 'ready to submit') $refs.field.blur(); clearTimeout(keyboardTipTimer); showKeyboardTooltip = false }"
+@update:modelValue="val => { ctx.emitValue(val); this.hideKeyboardTooltip() }"
+            @makeKeyAction="action => { if (action === 'ready to submit') $refs.field.blur(); this.hideKeyboardTooltip() }"
           :style="{
             left:0,
             right:0,
@@ -17,18 +17,22 @@
           }"
         />
       </template>
-      <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
-        {{ $t('PleaseUseCustomKeyboard') }}
-      </div>
     </q-field>
+    <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
   </div>
 </template>
 <script>
 import CustomKeyboard from './CustomKeyboard.vue';
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 
 export default {
   name: 'CustomKeyboardInput',
-  components: { CustomKeyboard },
+  components: { CustomKeyboard, KeyboardTooltip },
+  setup() {
+    const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
+    return { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip }
+  },
   props: {
     modelValue: {
       type: [Number, String],
@@ -42,9 +46,6 @@ export default {
   data () {
     return {
       val: this.modelValue,
-      keyboardTipTimer: null,
-      keyboardTipCounter: 0,
-      showKeyboardTooltip: false
     }
   },
   computed: {
@@ -55,14 +56,10 @@ export default {
   methods: {
     onKeyboardInput (e) {
       e.preventDefault()
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = true
-      this.keyboardTipCounter++
-      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
+      this.showKeyboardTooltip()
     },
     clearKeyboardTooltip () {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
     }
   },
   watch: {
@@ -77,47 +74,4 @@ export default {
 </script>
 
 <style scoped>
-.keyboard-tooltip-bubble {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  bottom: calc(100% + 10px);
-  z-index: 10;
-  white-space: nowrap;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 13px;
-  line-height: 1.4;
-  font-weight: 700;
-  pointer-events: none;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-  animation: shake 0.4s ease-in-out;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 7px solid transparent;
-  }
-
-  &.dark {
-    background: #d32f2f;
-    color: #fff;
-    &::after { border-top-color: #d32f2f; }
-  }
-
-  &.light {
-    background: #e53935;
-    color: #fff;
-    &::after { border-top-color: #e53935; }
-  }
-}
-
-@keyframes shake {
-  0%, 100% { transform: translateX(-50%); }
-  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-}
 </style>

--- a/src/components/CustomKeyboardInput.vue
+++ b/src/components/CustomKeyboardInput.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <q-skeleton v-if="fieldProps.wait" type="rect"/>
-    <q-field v-else v-model="val" ref="field" v-bind="fieldProps">
+    <q-field v-else v-model="val" ref="field" v-bind="fieldProps" @keydown="onKeyboardInput">
       <template v-slot:control="ctx">
         {{ ctx.modelValue }}
         <CustomKeyboard
           :modelValue="ctx.modelValue"
           :customKeyboardState="ctx.focused ? 'show': ''"
-          @update:modelValue="ctx.emitValue"
-          @makeKeyAction="action => action === 'ready to submit' ? $refs.field.blur(): null"
+           @update:modelValue="val => { ctx.emitValue(val); showKeyboardTooltip = false }"
+           @makeKeyAction="action => { if (action === 'ready to submit') $refs.field.blur(); showKeyboardTooltip = false }"
           :style="{
             left:0,
             right:0,
@@ -17,6 +17,9 @@
           }"
         />
       </template>
+      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+        {{ $t('PleaseUseCustomKeyboard') }}
+      </div>
     </q-field>
   </div>
 </template>
@@ -38,7 +41,17 @@ export default {
   },
   data () {
     return {
-      val: this.modelValue
+      val: this.modelValue,
+      showKeyboardTooltip: false
+    }
+  },
+  methods: {
+    onKeyboardInput (e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
+    },
+    clearKeyboardTooltip () {
+      this.showKeyboardTooltip = false
     }
   },
   watch: {

--- a/src/components/CustomKeyboardInput.vue
+++ b/src/components/CustomKeyboardInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div style="position: relative;">
     <q-skeleton v-if="fieldProps.wait" type="rect"/>
     <q-field v-else v-model="val" ref="field" v-bind="fieldProps" @keydown="onKeyboardInput">
       <template v-slot:control="ctx">
@@ -7,8 +7,8 @@
         <CustomKeyboard
           :modelValue="ctx.modelValue"
           :customKeyboardState="ctx.focused ? 'show': ''"
-           @update:modelValue="val => { ctx.emitValue(val); showKeyboardTooltip = false }"
-           @makeKeyAction="action => { if (action === 'ready to submit') $refs.field.blur(); showKeyboardTooltip = false }"
+           @update:modelValue="val => { ctx.emitValue(val); clearTimeout(keyboardTipTimer); showKeyboardTooltip = false }"
+           @makeKeyAction="action => { if (action === 'ready to submit') $refs.field.blur(); clearTimeout(keyboardTipTimer); showKeyboardTooltip = false }"
           :style="{
             left:0,
             right:0,
@@ -17,7 +17,7 @@
           }"
         />
       </template>
-      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+      <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
         {{ $t('PleaseUseCustomKeyboard') }}
       </div>
     </q-field>
@@ -42,15 +42,26 @@ export default {
   data () {
     return {
       val: this.modelValue,
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
       showKeyboardTooltip: false
+    }
+  },
+  computed: {
+    darkMode () {
+      return this.$store.getters['darkmode/getStatus']
     }
   },
   methods: {
     onKeyboardInput (e) {
       e.preventDefault()
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = true
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
     },
     clearKeyboardTooltip () {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
     }
   },
@@ -64,3 +75,49 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.keyboard-tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(100% + 10px);
+  z-index: 10;
+  white-space: nowrap;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 700;
+  pointer-events: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  animation: shake 0.4s ease-in-out;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 7px solid transparent;
+  }
+
+  &.dark {
+    background: #d32f2f;
+    color: #fff;
+    &::after { border-top-color: #d32f2f; }
+  }
+
+  &.light {
+    background: #e53935;
+    color: #fff;
+    &::after { border-top-color: #e53935; }
+  }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(-50%); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
+}
+</style>

--- a/src/components/KeyboardTooltip.vue
+++ b/src/components/KeyboardTooltip.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'">
+    {{ $t('PleaseUseCustomKeyboard') }}
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'KeyboardTooltip',
+  props: {
+    darkMode: { type: Boolean, default: false }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.keyboard-tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(100% + 10px);
+  z-index: 10;
+  white-space: nowrap;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 700;
+  pointer-events: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  animation: shake 0.4s ease-in-out;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 7px solid transparent;
+  }
+
+  &.dark {
+    background: #d32f2f;
+    color: #fff;
+
+    &::after {
+      border-top-color: #d32f2f;
+    }
+  }
+
+  &.light {
+    background: #e53935;
+    color: #fff;
+
+    &::after {
+      border-top-color: #e53935;
+    }
+  }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(-50%); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
+}
+</style>

--- a/src/components/KeyboardTooltip.vue
+++ b/src/components/KeyboardTooltip.vue
@@ -1,14 +1,19 @@
 <template>
-  <div class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'">
+  <div class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)">
     {{ $t('PleaseUseCustomKeyboard') }}
   </div>
 </template>
 
 <script>
+import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
+
 export default {
   name: 'KeyboardTooltip',
   props: {
     darkMode: { type: Boolean, default: false }
+  },
+  methods: {
+    getDarkModeClass
   }
 }
 </script>

--- a/src/components/anyhedge/CreateHedgeForm.vue
+++ b/src/components/anyhedge/CreateHedgeForm.vue
@@ -554,7 +554,6 @@ function makeKeyAction (action) {
   hideKeyboardTooltip()
   if (action === 'backspace') {
     // Backspace
-    this.shiftAmount = String(this.shiftAmount).slice(0, -1)
     if (activeInput.value === 'match') {
       createHedgeForm.value.p2pMatch.similarity = String(createHedgeForm.value.p2pMatch.similarity).slice(0, -1)
     } else if (activeInput.value === 'duration') {

--- a/src/components/anyhedge/CreateHedgeForm.vue
+++ b/src/components/anyhedge/CreateHedgeForm.vue
@@ -195,6 +195,7 @@
         inputmode="none"
         @focus="readonlyState(true, 'amount')"
         @blur="readonlyState(false, 'amount')"
+        @keydown="onKeyboardInput"
         :dark="darkMode"
         outlined
         dense
@@ -215,6 +216,9 @@
           </div>
         </template>
       </q-input>
+      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+        {{ $t('PleaseUseCustomKeyboard') }}
+      </div>
       <q-select
         :dark="darkMode"
         outlined
@@ -468,10 +472,17 @@ let inputState = ref({
 })
 let activeInput = ref()
 let durationRef = ref()
+const showKeyboardTooltip = ref(false)
 const amountInputFormatted = ref(0)
 const isBalanceClicked = ref(false)
 
+function onKeyboardInput (e) {
+  e.preventDefault()
+  showKeyboardTooltip.value = true
+}
+
 function readonlyState (state, type) {
+  if (state) showKeyboardTooltip.value = false
   inputState[type] = state
 
   if (inputState[type]) {
@@ -481,6 +492,7 @@ function readonlyState (state, type) {
 }
 
 function setAmount (key) {
+  showKeyboardTooltip.value = false
   let tempAmount, amount, tempAmountInput = '', amountInput
 
   // Set Initial Input
@@ -537,6 +549,7 @@ function setAmount (key) {
 }
 
 function makeKeyAction (action) {
+  showKeyboardTooltip.value = false
   if (action === 'backspace') {
     // Backspace
     this.shiftAmount = String(this.shiftAmount).slice(0, -1)

--- a/src/components/anyhedge/CreateHedgeForm.vue
+++ b/src/components/anyhedge/CreateHedgeForm.vue
@@ -216,9 +216,7 @@
           </div>
         </template>
       </q-input>
-      <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
-        {{ $t('PleaseUseCustomKeyboard') }}
-      </div>
+      <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
       <q-select
         :dark="darkMode"
         outlined
@@ -449,6 +447,8 @@ import DurationField from './DurationField.vue';
 import { getAssetDenomination, parseFiatCurrency, convertToBCH } from 'src/utils/denomination-utils'
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
 import { useI18n } from 'vue-i18n'
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 
 
 function alertError(...args) {
@@ -472,24 +472,18 @@ let inputState = ref({
 })
 let activeInput = ref()
 let durationRef = ref()
-const showKeyboardTooltip = ref(false)
-const keyboardTipTimer = ref(null)
-const keyboardTipCounter = ref(0)
+const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
 const amountInputFormatted = ref(0)
 const isBalanceClicked = ref(false)
 
 function onKeyboardInput (e) {
   e.preventDefault()
-  clearTimeout(keyboardTipTimer.value)
-  showKeyboardTooltip.value = true
-  keyboardTipCounter.value++
-  keyboardTipTimer.value = setTimeout(() => { showKeyboardTooltip.value = false }, 10000)
+  showKeyboardTooltip()
 }
 
 function readonlyState (state, type) {
   if (state) {
-    clearTimeout(keyboardTipTimer.value)
-    showKeyboardTooltip.value = false
+    hideKeyboardTooltip()
   }
   inputState[type] = state
 
@@ -500,8 +494,7 @@ function readonlyState (state, type) {
 }
 
 function setAmount (key) {
-  clearTimeout(keyboardTipTimer.value)
-  showKeyboardTooltip.value = false
+  hideKeyboardTooltip()
   let tempAmount, amount, tempAmountInput = '', amountInput
 
   // Set Initial Input
@@ -558,8 +551,7 @@ function setAmount (key) {
 }
 
 function makeKeyAction (action) {
-  clearTimeout(keyboardTipTimer.value)
-  showKeyboardTooltip.value = false
+  hideKeyboardTooltip()
   if (action === 'backspace') {
     // Backspace
     this.shiftAmount = String(this.shiftAmount).slice(0, -1)
@@ -1606,53 +1598,5 @@ function amountRules (val) {
   opacity: 0.65;
 }
 
-.keyboard-tooltip-bubble {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  bottom: calc(100% + 10px);
-  z-index: 10;
-  white-space: nowrap;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 13px;
-  line-height: 1.4;
-  font-weight: 700;
-  pointer-events: none;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-  animation: shake 0.4s ease-in-out;
-}
 
-.keyboard-tooltip-bubble::after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 7px solid transparent;
-}
-
-.keyboard-tooltip-bubble.dark {
-  background: #d32f2f;
-  color: #fff;
-}
-
-.keyboard-tooltip-bubble.dark::after {
-  border-top-color: #d32f2f;
-}
-
-.keyboard-tooltip-bubble.light {
-  background: #e53935;
-  color: #fff;
-}
-
-.keyboard-tooltip-bubble.light::after {
-  border-top-color: #e53935;
-}
-
-@keyframes shake {
-  0%, 100% { transform: translateX(-50%); }
-  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-}
 </style>

--- a/src/components/anyhedge/CreateHedgeForm.vue
+++ b/src/components/anyhedge/CreateHedgeForm.vue
@@ -189,7 +189,7 @@
         </q-popup-proxy>
       </q-icon>
     </div>
-    <div class="row no-wrap q-gutter-x-sm">
+    <div class="row no-wrap q-gutter-x-sm" style="position: relative;">
       <q-input
         type="text"
         inputmode="none"
@@ -216,7 +216,7 @@
           </div>
         </template>
       </q-input>
-      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+      <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
         {{ $t('PleaseUseCustomKeyboard') }}
       </div>
       <q-select
@@ -473,16 +473,24 @@ let inputState = ref({
 let activeInput = ref()
 let durationRef = ref()
 const showKeyboardTooltip = ref(false)
+const keyboardTipTimer = ref(null)
+const keyboardTipCounter = ref(0)
 const amountInputFormatted = ref(0)
 const isBalanceClicked = ref(false)
 
 function onKeyboardInput (e) {
   e.preventDefault()
+  clearTimeout(keyboardTipTimer.value)
   showKeyboardTooltip.value = true
+  keyboardTipCounter.value++
+  keyboardTipTimer.value = setTimeout(() => { showKeyboardTooltip.value = false }, 10000)
 }
 
 function readonlyState (state, type) {
-  if (state) showKeyboardTooltip.value = false
+  if (state) {
+    clearTimeout(keyboardTipTimer.value)
+    showKeyboardTooltip.value = false
+  }
   inputState[type] = state
 
   if (inputState[type]) {
@@ -492,6 +500,7 @@ function readonlyState (state, type) {
 }
 
 function setAmount (key) {
+  clearTimeout(keyboardTipTimer.value)
   showKeyboardTooltip.value = false
   let tempAmount, amount, tempAmountInput = '', amountInput
 
@@ -549,6 +558,7 @@ function setAmount (key) {
 }
 
 function makeKeyAction (action) {
+  clearTimeout(keyboardTipTimer.value)
   showKeyboardTooltip.value = false
   if (action === 'backspace') {
     // Backspace
@@ -1594,5 +1604,55 @@ function amountRules (val) {
 
 .disabled-pool-option {
   opacity: 0.65;
+}
+
+.keyboard-tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(100% + 10px);
+  z-index: 10;
+  white-space: nowrap;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 700;
+  pointer-events: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  animation: shake 0.4s ease-in-out;
+}
+
+.keyboard-tooltip-bubble::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 7px solid transparent;
+}
+
+.keyboard-tooltip-bubble.dark {
+  background: #d32f2f;
+  color: #fff;
+}
+
+.keyboard-tooltip-bubble.dark::after {
+  border-top-color: #d32f2f;
+}
+
+.keyboard-tooltip-bubble.light {
+  background: #e53935;
+  color: #fff;
+}
+
+.keyboard-tooltip-bubble.light::after {
+  border-top-color: #e53935;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(-50%); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
 }
 </style>

--- a/src/components/ramp/crypto/RampShiftForm.vue
+++ b/src/components/ramp/crypto/RampShiftForm.vue
@@ -26,7 +26,7 @@
               {{getNetwork(deposit)}}
             </q-item-label> -->
           </q-item-section>
-          <q-item-section>
+          <q-item-section style="position: relative;">
             <q-input
               dense
               filled
@@ -40,7 +40,7 @@
                   updateConvertionRate()
                 }"              
             />
-            <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+            <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
               {{ $t('PleaseUseCustomKeyboard') }}
             </div>
             <q-item-label
@@ -288,6 +288,8 @@ export default {
       prefix: ['ethereum'],
       readonlyState: false,
       showKeyboardTooltip: false,
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
       customKeyboardState: 'dismiss'      
     }
   },
@@ -312,7 +314,10 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = true
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
     },
     openCustomKeyboard (state) {
       this.readonlyState = state
@@ -350,10 +355,12 @@ export default {
           }
         }
         this.shiftAmount = finalAmount
+        clearTimeout(this.keyboardTipTimer)
         this.showKeyboardTooltip = false
         this.updateConvertionRate()        
     },
     makeKeyAction (action) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       if (action === 'backspace') {
         // Backspace
@@ -974,5 +981,49 @@ export default {
     to {
       opacity: 1;
     }
+  }
+
+  .keyboard-tooltip-bubble {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(100% + 10px);
+    z-index: 10;
+    white-space: nowrap;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    font-weight: 700;
+    pointer-events: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    animation: shake 0.4s ease-in-out;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 7px solid transparent;
+    }
+
+    &.dark {
+      background: #d32f2f;
+      color: #fff;
+      &::after { border-top-color: #d32f2f; }
+    }
+
+    &.light {
+      background: #e53935;
+      color: #fff;
+      &::after { border-top-color: #e53935; }
+    }
+  }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(-50%); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
   }
 </style>

--- a/src/components/ramp/crypto/RampShiftForm.vue
+++ b/src/components/ramp/crypto/RampShiftForm.vue
@@ -40,9 +40,7 @@
                   updateConvertionRate()
                 }"              
             />
-            <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
-              {{ $t('PleaseUseCustomKeyboard') }}
-            </div>
+            <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
             <q-item-label
               class="text-right q-mt-sm"
               caption
@@ -234,6 +232,8 @@ import CustomKeyboard from 'src/components/CustomKeyboard.vue'
 import QrScanner from 'src/components/qr-scanner.vue'
 import { debounce } from 'quasar'
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 import { bus } from 'src/wallet/event-bus.js'
 import { isConformingNamespaces } from '@walletconnect/utils'
 import {
@@ -249,7 +249,12 @@ export default {
     RampDisplayConfirmation,
     RampDepositInfo,
     CustomKeyboard,
-    QrScanner
+    QrScanner,
+    KeyboardTooltip
+  },
+  setup() {
+    const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
+    return { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip }
   },
   data () {
     return {
@@ -287,9 +292,6 @@ export default {
       depositInfoState: 'created',
       prefix: ['ethereum'],
       readonlyState: false,
-      showKeyboardTooltip: false,
-      keyboardTipTimer: null,
-      keyboardTipCounter: 0,
       customKeyboardState: 'dismiss'      
     }
   },
@@ -314,10 +316,7 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = true
-      this.keyboardTipCounter++
-      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
+      this.showKeyboardTooltip()
     },
     openCustomKeyboard (state) {
       this.readonlyState = state
@@ -355,13 +354,11 @@ export default {
           }
         }
         this.shiftAmount = finalAmount
-        clearTimeout(this.keyboardTipTimer)
-        this.showKeyboardTooltip = false
+        this.hideKeyboardTooltip()
         this.updateConvertionRate()        
     },
     makeKeyAction (action) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       if (action === 'backspace') {
         // Backspace
         this.shiftAmount = String(this.shiftAmount).slice(0, -1)
@@ -983,47 +980,4 @@ export default {
     }
   }
 
-  .keyboard-tooltip-bubble {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: calc(100% + 10px);
-    z-index: 10;
-    white-space: nowrap;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-size: 13px;
-    line-height: 1.4;
-    font-weight: 700;
-    pointer-events: none;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    animation: shake 0.4s ease-in-out;
-
-    &::after {
-      content: '';
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      border: 7px solid transparent;
-    }
-
-    &.dark {
-      background: #d32f2f;
-      color: #fff;
-      &::after { border-top-color: #d32f2f; }
-    }
-
-    &.light {
-      background: #e53935;
-      color: #fff;
-      &::after { border-top-color: #e53935; }
-    }
-  }
-
-  @keyframes shake {
-    0%, 100% { transform: translateX(-50%); }
-    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-  }
 </style>

--- a/src/components/ramp/crypto/RampShiftForm.vue
+++ b/src/components/ramp/crypto/RampShiftForm.vue
@@ -35,10 +35,14 @@
               v-model="shiftAmount"
               :readonly="readonlyState"
               @focus="openCustomKeyboard(true)"
+              @keydown="onKeyboardInput"
               @update:modelValue="function(){
                   updateConvertionRate()
                 }"              
             />
+            <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+              {{ $t('PleaseUseCustomKeyboard') }}
+            </div>
             <q-item-label
               class="text-right q-mt-sm"
               caption
@@ -283,6 +287,7 @@ export default {
       depositInfoState: 'created',
       prefix: ['ethereum'],
       readonlyState: false,
+      showKeyboardTooltip: false,
       customKeyboardState: 'dismiss'      
     }
   },
@@ -304,6 +309,10 @@ export default {
       //   params: { id: data.shift_id },
       //   state: { details: jsonString}
       // })
+    },
+    onKeyboardInput (e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
     },
     openCustomKeyboard (state) {
       this.readonlyState = state
@@ -341,9 +350,11 @@ export default {
           }
         }
         this.shiftAmount = finalAmount
+        this.showKeyboardTooltip = false
         this.updateConvertionRate()        
     },
     makeKeyAction (action) {
+      this.showKeyboardTooltip = false
       if (action === 'backspace') {
         // Backspace
         this.shiftAmount = String(this.shiftAmount).slice(0, -1)

--- a/src/components/ramp/fiat/dialogs/FilterSelectionDialog.vue
+++ b/src/components/ramp/fiat/dialogs/FilterSelectionDialog.vue
@@ -22,9 +22,7 @@
               <span class="text-bold" style="font-size: 15px;">{{ byFiat ? currency.symbol : 'BCH' }}</span>
             </template>
           </q-input>
-          <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
-            {{ $t('PleaseUseCustomKeyboard') }}
-          </div>
+          <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
           <div class="q-pl-sm q-pt-sm">
             <q-btn
               class="sm-font-size button button-text-primary"
@@ -97,6 +95,8 @@
 <script>
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
 import customKeyboard from 'src/components/CustomKeyboard.vue';
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 
 export default {
   data () {
@@ -107,15 +107,17 @@ export default {
       filter: null,
       byFiat: true,
       readonlyState: false,
-      showKeyboardTooltip: false,
-      keyboardTipTimer: null,
-      keyboardTipCounter: 0,
       customKeyboardState: 'dismiss',
       loadFilterButton: false
     }
   },
   components: {
-    customKeyboard
+    customKeyboard,
+    KeyboardTooltip
+  },
+  setup() {
+    const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
+    return { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip }
   },
   computed: {
     disableUnselectBtn () {
@@ -218,13 +220,11 @@ export default {
           }
         }
         this.amount = finalAmount
-        clearTimeout(this.keyboardTipTimer)
-        this.showKeyboardTooltip = false
+        this.hideKeyboardTooltip()
       }
     },
     makeKeyAction (action) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       if (action === 'backspace') {
         // Backspace
         this.amount = String(this.amount).slice(0, -1)
@@ -238,10 +238,7 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = true
-      this.keyboardTipCounter++
-      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
+      this.showKeyboardTooltip()
     },
     openCustomKeyboard (state) {
       this.readonlyState = state
@@ -263,47 +260,4 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-  .keyboard-tooltip-bubble {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: calc(100% + 10px);
-    z-index: 10;
-    white-space: nowrap;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-size: 13px;
-    line-height: 1.4;
-    font-weight: 700;
-    pointer-events: none;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    animation: shake 0.4s ease-in-out;
-
-    &::after {
-      content: '';
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      border: 7px solid transparent;
-    }
-
-    &.dark {
-      background: #d32f2f;
-      color: #fff;
-      &::after { border-top-color: #d32f2f; }
-    }
-
-    &.light {
-      background: #e53935;
-      color: #fff;
-      &::after { border-top-color: #e53935; }
-    }
-  }
-
-  @keyframes shake {
-    0%, 100% { transform: translateX(-50%); }
-    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-  }
 </style>

--- a/src/components/ramp/fiat/dialogs/FilterSelectionDialog.vue
+++ b/src/components/ramp/fiat/dialogs/FilterSelectionDialog.vue
@@ -7,7 +7,7 @@
       </div>
       <div class="q-px-lg q-pt-sm text-center text-bold" style="font-size: medium;">{{ filterTypeText }}</div>
       <div class="q-pt-sm q-pb-md q-px-lg">
-        <div v-if="type === 'amount'">
+        <div v-if="type === 'amount'" style="position: relative;">
           <q-input
             dense
             rounded
@@ -22,7 +22,7 @@
               <span class="text-bold" style="font-size: 15px;">{{ byFiat ? currency.symbol : 'BCH' }}</span>
             </template>
           </q-input>
-          <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs q-ml-sm">
+          <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
             {{ $t('PleaseUseCustomKeyboard') }}
           </div>
           <div class="q-pl-sm q-pt-sm">
@@ -108,6 +108,8 @@ export default {
       byFiat: true,
       readonlyState: false,
       showKeyboardTooltip: false,
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
       customKeyboardState: 'dismiss',
       loadFilterButton: false
     }
@@ -216,10 +218,12 @@ export default {
           }
         }
         this.amount = finalAmount
+        clearTimeout(this.keyboardTipTimer)
         this.showKeyboardTooltip = false
       }
     },
     makeKeyAction (action) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       if (action === 'backspace') {
         // Backspace
@@ -234,7 +238,10 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = true
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
     },
     openCustomKeyboard (state) {
       this.readonlyState = state
@@ -255,3 +262,48 @@ export default {
   }
 }
 </script>
+<style lang="scss" scoped>
+  .keyboard-tooltip-bubble {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(100% + 10px);
+    z-index: 10;
+    white-space: nowrap;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    font-weight: 700;
+    pointer-events: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    animation: shake 0.4s ease-in-out;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 7px solid transparent;
+    }
+
+    &.dark {
+      background: #d32f2f;
+      color: #fff;
+      &::after { border-top-color: #d32f2f; }
+    }
+
+    &.light {
+      background: #e53935;
+      color: #fff;
+      &::after { border-top-color: #e53935; }
+    }
+  }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(-50%); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
+  }
+</style>

--- a/src/components/ramp/fiat/dialogs/FilterSelectionDialog.vue
+++ b/src/components/ramp/fiat/dialogs/FilterSelectionDialog.vue
@@ -15,12 +15,16 @@
             v-model="amount"
             :placeholder="$t('EnterAmount')"
             @focus="openCustomKeyboard(true)"
+            @keydown="onKeyboardInput"
             :readonly="readonlyState"
             >
             <template v-slot:append>
               <span class="text-bold" style="font-size: 15px;">{{ byFiat ? currency.symbol : 'BCH' }}</span>
             </template>
           </q-input>
+          <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs q-ml-sm">
+            {{ $t('PleaseUseCustomKeyboard') }}
+          </div>
           <div class="q-pl-sm q-pt-sm">
             <q-btn
               class="sm-font-size button button-text-primary"
@@ -103,6 +107,7 @@ export default {
       filter: null,
       byFiat: true,
       readonlyState: false,
+      showKeyboardTooltip: false,
       customKeyboardState: 'dismiss',
       loadFilterButton: false
     }
@@ -211,9 +216,11 @@ export default {
           }
         }
         this.amount = finalAmount
+        this.showKeyboardTooltip = false
       }
     },
     makeKeyAction (action) {
+      this.showKeyboardTooltip = false
       if (action === 'backspace') {
         // Backspace
         this.amount = String(this.amount).slice(0, -1)
@@ -224,6 +231,10 @@ export default {
         this.customKeyboardState = 'dismiss'
         this.readonlyState = false
       }
+    },
+    onKeyboardInput (e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
     },
     openCustomKeyboard (state) {
       this.readonlyState = state

--- a/src/components/rewards/dialogs/RedeemPointsDialog.vue
+++ b/src/components/rewards/dialogs/RedeemPointsDialog.vue
@@ -79,9 +79,7 @@
                 </div>
               </template>
             </q-input>
-            <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
-              {{ $t('PleaseUseCustomKeyboard') }}
-            </div>
+            <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
           </div>
 
           <div class="row justify-between q-mb-sm q-mx-sm">
@@ -180,9 +178,7 @@
                 </div>
               </template>
             </q-input>
-            <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
-              {{ $t('PleaseUseCustomKeyboard') }}
-            </div>
+            <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
           </div>
 
           <div class="row justify-between q-mb-sm q-mx-sm">
@@ -267,6 +263,8 @@
 <script>
 import { NativeBiometric } from 'capacitor-native-biometric'
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 import {
   generateReceivingAddress,
   getDerivationPathForWalletType
@@ -304,15 +302,17 @@ export default {
     CustomKeyboard,
     BiometricWarningAttempt,
     PinDialog,
-    ProgressLoader
+    ProgressLoader,
+    KeyboardTooltip
+  },
+  setup() {
+    const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
+    return { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip }
   },
 
   data () {
     return {
       pointsToRedeem: '0',
-      showKeyboardTooltip: false,
-      keyboardTipTimer: null,
-      keyboardTipCounter: 0,
       customKeyboardState: 'dismiss',
       pointsBalance: 0,
       redeemablePointsBalance: 0,
@@ -360,14 +360,10 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = true
-      this.keyboardTipCounter++
-      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
+      this.showKeyboardTooltip()
     },
     setAmount (key) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       const vm = this
 
       const currentPoints = vm.pointsToRedeem
@@ -378,8 +374,7 @@ export default {
       vm.computeBalance()
     },
     makeKeyAction (action) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       const vm = this
 
       if (action === 'backspace') {
@@ -536,47 +531,5 @@ export default {
   }
 }
 
-  .keyboard-tooltip-bubble {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: calc(100% + 10px);
-    z-index: 10;
-    white-space: nowrap;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-size: 13px;
-    line-height: 1.4;
-    font-weight: 700;
-    pointer-events: none;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    animation: shake 0.4s ease-in-out;
 
-    &::after {
-      content: '';
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      border: 7px solid transparent;
-    }
-
-    &.dark {
-      background: #d32f2f;
-      color: #fff;
-      &::after { border-top-color: #d32f2f; }
-    }
-
-    &.light {
-      background: #e53935;
-      color: #fff;
-      &::after { border-top-color: #e53935; }
-    }
-  }
-
-  @keyframes shake {
-    0%, 100% { transform: translateX(-50%); }
-    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-  }
 </style>

--- a/src/components/rewards/dialogs/RedeemPointsDialog.vue
+++ b/src/components/rewards/dialogs/RedeemPointsDialog.vue
@@ -62,6 +62,7 @@
               type="text"
               inputmode="none"
               @focus="customKeyboardState = 'show'"
+              @keydown="onKeyboardInput"
               filled
               v-model="pointsToRedeem"
               :label="$t('Amount')"
@@ -159,6 +160,7 @@
               type="text"
               inputmode="none"
               @focus="customKeyboardState = 'show'"
+              @keydown="onKeyboardInput"
               filled
               v-model="pointsToRedeem"
               :label="$t('Amount')"
@@ -302,6 +304,7 @@ export default {
   data () {
     return {
       pointsToRedeem: '0',
+      showKeyboardTooltip: false,
       customKeyboardState: 'dismiss',
       pointsBalance: 0,
       redeemablePointsBalance: 0,
@@ -347,7 +350,12 @@ export default {
       this.pointsToRedeem = '' + this.points
       this.computeBalance()
     },
+    onKeyboardInput (e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
+    },
     setAmount (key) {
+      this.showKeyboardTooltip = false
       const vm = this
 
       const currentPoints = vm.pointsToRedeem
@@ -358,6 +366,7 @@ export default {
       vm.computeBalance()
     },
     makeKeyAction (action) {
+      this.showKeyboardTooltip = false
       const vm = this
 
       if (action === 'backspace') {

--- a/src/components/rewards/dialogs/RedeemPointsDialog.vue
+++ b/src/components/rewards/dialogs/RedeemPointsDialog.vue
@@ -56,7 +56,7 @@
             </span>
           </div>
 
-          <div class="q-mt-md q-mb-sm">
+          <div class="q-mt-md q-mb-sm" style="position: relative;">
             <q-input
               ref="points-input"
               type="text"
@@ -79,6 +79,9 @@
                 </div>
               </template>
             </q-input>
+            <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
+              {{ $t('PleaseUseCustomKeyboard') }}
+            </div>
           </div>
 
           <div class="row justify-between q-mb-sm q-mx-sm">
@@ -154,7 +157,7 @@
             </span>
           </div>
 
-          <div class="q-mt-md q-mb-sm">
+          <div class="q-mt-md q-mb-sm" style="position: relative;">
             <q-input
               ref="points-input"
               type="text"
@@ -177,6 +180,9 @@
                 </div>
               </template>
             </q-input>
+            <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
+              {{ $t('PleaseUseCustomKeyboard') }}
+            </div>
           </div>
 
           <div class="row justify-between q-mb-sm q-mx-sm">
@@ -305,6 +311,8 @@ export default {
     return {
       pointsToRedeem: '0',
       showKeyboardTooltip: false,
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
       customKeyboardState: 'dismiss',
       pointsBalance: 0,
       redeemablePointsBalance: 0,
@@ -352,9 +360,13 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = true
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
     },
     setAmount (key) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       const vm = this
 
@@ -366,6 +378,7 @@ export default {
       vm.computeBalance()
     },
     makeKeyAction (action) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       const vm = this
 
@@ -522,4 +535,48 @@ export default {
     color: #6fa8ff;
   }
 }
+
+  .keyboard-tooltip-bubble {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(100% + 10px);
+    z-index: 10;
+    white-space: nowrap;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    font-weight: 700;
+    pointer-events: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    animation: shake 0.4s ease-in-out;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 7px solid transparent;
+    }
+
+    &.dark {
+      background: #d32f2f;
+      color: #fff;
+      &::after { border-top-color: #d32f2f; }
+    }
+
+    &.light {
+      background: #e53935;
+      color: #fff;
+      &::after { border-top-color: #e53935; }
+    }
+  }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(-50%); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
+  }
 </style>

--- a/src/components/send-page/SendPageForm.vue
+++ b/src/components/send-page/SendPageForm.vue
@@ -100,6 +100,7 @@
         ref="amountInput"
         class="bch-input-field"
         @focus="onInputFocus(index, 'bch')"
+        @keydown="onKeyboardInput"
         :label="cauldronEnabled ? $t('ReceiveAmount') : $t('Amount')"
         :dark="darkMode"
         :loading="computingMax"
@@ -121,6 +122,9 @@
           />
         </template>
       </q-input>
+      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+        {{ $t('PleaseUseCustomKeyboard') }}
+      </div>
     </div>
   </div>
 
@@ -134,6 +138,7 @@
         ref="fiatInput"
         class="fiat-input-field"
         @focus="onInputFocus(index, 'fiat')"
+        @keydown="onKeyboardInput"
         :disabled="recipient.fixedAmount || inputExtras.isBip21"
         :readonly="recipient.fixedAmount || inputExtras.isBip21"
         :error="balanceExceeded && !cauldronEnabled"
@@ -146,7 +151,11 @@
           {{ String(currentSendPageCurrency()).toUpperCase() }}
         </template>
       </q-input>
+      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+        {{ $t('PleaseUseCustomKeyboard') }}
+      </div>
     </div>
+  </div>
   </div>
 
   <div v-if="!isNFT && !cauldronEnabled" class="q-mt-sm">
@@ -323,6 +332,7 @@ export default {
       cauldronEnabled: false,
       cauldronAmount: '',
       cauldronAmountFormatted: '',
+      showKeyboardTooltip: false,
     }
   },
 
@@ -444,7 +454,12 @@ export default {
           this.setMaximumSendAmount()
         })
     },
+    onKeyboardInput (e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
+    },
     onInputFocus (index, field) {
+      this.showKeyboardTooltip = false
       this.$emit('on-input-focus', { index, field })
     },
     onSelectedDenomination (value) {
@@ -566,6 +581,12 @@ export default {
       handler() {
         this.syncPropsData();
       },
+    },
+    amountFormatted () {
+      this.showKeyboardTooltip = false
+    },
+    fiatFormatted () {
+      this.showKeyboardTooltip = false
     },
   }
 }

--- a/src/components/send-page/SendPageForm.vue
+++ b/src/components/send-page/SendPageForm.vue
@@ -122,9 +122,7 @@
           />
         </template>
       </q-input>
-      <div v-if="activeKeyboardTip === 'bch'" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="'bch-' + keyboardTipCounter">
-        {{ $t('PleaseUseCustomKeyboard') }}
-      </div>
+      <KeyboardTooltip v-if="activeKeyboardTip === 'bch'" :dark-mode="darkMode" :key="'bch-' + keyboardTipCounter" />
     </div>
   </div>
 
@@ -151,9 +149,7 @@
           {{ String(currentSendPageCurrency()).toUpperCase() }}
         </template>
       </q-input>
-      <div v-if="activeKeyboardTip === 'fiat'" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="'fiat-' + keyboardTipCounter">
-        {{ $t('PleaseUseCustomKeyboard') }}
-      </div>
+      <KeyboardTooltip v-if="activeKeyboardTip === 'fiat'" :dark-mode="darkMode" :key="'fiat-' + keyboardTipCounter" />
     </div>
   </div>
   <div v-if="!isNFT && !cauldronEnabled" class="q-mt-sm">
@@ -263,9 +259,11 @@ import { shortenAddressForDisplay } from 'src/utils/address-utils'
 import { convertToFiatAmount } from 'src/utils/send-page-utils'
 
 import SelectChangeAddress from 'src/components/SelectChangeAddress.vue'
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
 
 export default {
   components: {
+    KeyboardTooltip,
     DenominatorTextDropdown,
     TokenSelectDialog
   },
@@ -335,6 +333,10 @@ export default {
       keyboardTipCounter: 0,
       currentFocusedField: null,
     }
+  },
+
+  beforeUnmount () {
+    clearTimeout(this.keyboardTipTimer)
   },
 
   beforeMount () {
@@ -630,55 +632,6 @@ export default {
     }
   }
 
-  .keyboard-tooltip-bubble {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: calc(100% + 10px);
-    z-index: 10;
-    white-space: nowrap;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-size: 13px;
-    line-height: 1.4;
-    font-weight: 700;
-    pointer-events: none;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    animation: shake 0.4s ease-in-out;
-
-    &::after {
-      content: '';
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      border: 7px solid transparent;
-    }
-
-    &.dark {
-      background: #d32f2f;
-      color: #fff;
-
-      &::after {
-        border-top-color: #d32f2f;
-      }
-    }
-
-    &.light {
-      background: #e53935;
-      color: #fff;
-
-      &::after {
-        border-top-color: #e53935;
-      }
-    }
-  }
-
-  @keyframes shake {
-    0%, 100% { transform: translateX(-50%); }
-    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-  }
 </style>
 
 <style lang="scss">

--- a/src/components/send-page/SendPageForm.vue
+++ b/src/components/send-page/SendPageForm.vue
@@ -91,7 +91,7 @@
     </q-input>
   </div>
   <div class="row" v-if="!isNFT">
-    <div class="col q-mt-xs">
+    <div class="col q-mt-xs" style="position: relative;">
       <q-input
         type="text"
         inputmode="none"
@@ -122,14 +122,14 @@
           />
         </template>
       </q-input>
-      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+      <div v-if="activeKeyboardTip === 'bch'" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="'bch-' + keyboardTipCounter">
         {{ $t('PleaseUseCustomKeyboard') }}
       </div>
     </div>
   </div>
 
   <div class="row" v-if="!isNFT && asset?.id === 'bch'">
-    <div class="col q-mt-xs">
+    <div class="col q-mt-xs" style="position: relative;">
       <q-input
         type="text"
         inputmode="none"
@@ -151,13 +151,11 @@
           {{ String(currentSendPageCurrency()).toUpperCase() }}
         </template>
       </q-input>
-      <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+      <div v-if="activeKeyboardTip === 'fiat'" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="'fiat-' + keyboardTipCounter">
         {{ $t('PleaseUseCustomKeyboard') }}
       </div>
     </div>
   </div>
-  </div>
-
   <div v-if="!isNFT && !cauldronEnabled" class="q-mt-sm">
     <q-btn
       no-caps
@@ -332,7 +330,10 @@ export default {
       cauldronEnabled: false,
       cauldronAmount: '',
       cauldronAmountFormatted: '',
-      showKeyboardTooltip: false,
+      activeKeyboardTip: null,
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
+      currentFocusedField: null,
     }
   },
 
@@ -456,10 +457,15 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
-      this.showKeyboardTooltip = true
+      clearTimeout(this.keyboardTipTimer)
+      this.activeKeyboardTip = this.currentFocusedField
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.activeKeyboardTip = null }, 10000)
     },
     onInputFocus (index, field) {
-      this.showKeyboardTooltip = false
+      clearTimeout(this.keyboardTipTimer)
+      this.activeKeyboardTip = null
+      this.currentFocusedField = field
       this.$emit('on-input-focus', { index, field })
     },
     onSelectedDenomination (value) {
@@ -583,10 +589,12 @@ export default {
       },
     },
     amountFormatted () {
-      this.showKeyboardTooltip = false
+      clearTimeout(this.keyboardTipTimer)
+      this.activeKeyboardTip = null
     },
     fiatFormatted () {
-      this.showKeyboardTooltip = false
+      clearTimeout(this.keyboardTipTimer)
+      this.activeKeyboardTip = null
     },
   }
 }
@@ -620,6 +628,56 @@ export default {
       font-size: 12px;
       font-weight: bold;
     }
+  }
+
+  .keyboard-tooltip-bubble {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(100% + 10px);
+    z-index: 10;
+    white-space: nowrap;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    font-weight: 700;
+    pointer-events: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    animation: shake 0.4s ease-in-out;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 7px solid transparent;
+    }
+
+    &.dark {
+      background: #d32f2f;
+      color: #fff;
+
+      &::after {
+        border-top-color: #d32f2f;
+      }
+    }
+
+    &.light {
+      background: #e53935;
+      color: #fff;
+
+      &::after {
+        border-top-color: #e53935;
+      }
+    }
+  }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(-50%); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
   }
 </style>
 

--- a/src/composables/useKeyboardTooltip.js
+++ b/src/composables/useKeyboardTooltip.js
@@ -1,0 +1,25 @@
+import { ref, onUnmounted } from 'vue'
+
+export function useKeyboardTooltip () {
+  const showTooltip = ref(false)
+  const tipCounter = ref(0)
+  let tipTimer = null
+
+  function showKeyboardTooltip () {
+    clearTimeout(tipTimer)
+    showTooltip.value = true
+    tipCounter.value++
+    tipTimer = setTimeout(() => { showTooltip.value = false }, 10000)
+  }
+
+  function hideKeyboardTooltip () {
+    clearTimeout(tipTimer)
+    showTooltip.value = false
+  }
+
+  onUnmounted(() => {
+    clearTimeout(tipTimer)
+  })
+
+  return { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip }
+}

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -1632,6 +1632,7 @@ export default {
   PleaseEnterNickname: "Please enter nickname",
   PleasePay: "Please pay",
   PleaseUnselectUnsupportedPaymentMethods: "Please unselect unsupported payment methods",
+  PleaseUseCustomKeyboard: "Please use the custom keyboard",
   PleaseWaitGift: "Please wait while we create your gift",
   PleaseWaitMoment: "Please wait a moment",
   Plus: "Plus",

--- a/src/pages/apps/exchange/peer_to_peer/order-form.vue
+++ b/src/pages/apps/exchange/peer_to_peer/order-form.vue
@@ -133,9 +133,7 @@
                     <span>{{ byFiat ? ad?.fiat_currency?.symbol : 'BCH' }}</span>
                   </template>
                 </q-input>
-                <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
-                  {{ $t('PleaseUseCustomKeyboard') }}
-                </div>
+                <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
                 <div class="row justify-between">
                   <div v-if="amountError" class="col text-left text-weight-bold subtext sm-font-size q-pl-sm text-red">
                     {{ amountError }}
@@ -300,12 +298,19 @@ import { fetchUser } from 'src/exchange/auth'
 import { loadChatIdentity } from 'src/exchange/chat'
 import ShareDialog from 'src/components/ramp/fiat/dialogs/ShareDialog.vue'
 import { getFiatCurrencyFractionDigits, parseFiatCurrency } from 'src/utils/denomination-utils'
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 
 export default {
   setup () {
     const scrollTargetRef = ref(null)
+    const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
     return {
       scrollTargetRef,
+      showTooltip,
+      tipCounter,
+      showKeyboardTooltip,
+      hideKeyboardTooltip,
       scrollDown () {
         const x = setTimeout(() => {
           const scrollElement = scrollTargetRef.value.$el
@@ -315,6 +320,7 @@ export default {
     }
   },
   components: {
+    KeyboardTooltip,
     CustomKeyboard,
     AddPaymentMethods,
     MiscDialogs,
@@ -330,9 +336,6 @@ export default {
       isloaded: false,
       minHeight: this.$q.platform.is.ios ? this.$q.screen.height - (90 + 120) : this.$q.screen.height - (70 + 100),
       customKeyboardState: 'dismiss',
-      showKeyboardTooltip: false,
-      keyboardTipTimer: null,
-      keyboardTipCounter: 0,
       readonlyState: false,
       ad: null,
       state: 'initial',
@@ -578,12 +581,9 @@ export default {
       }
       this.shiftAmount = 0
       this.amount = finalAmount
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
     },
     makeKeyAction (action) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       if (action === 'backspace') {
         // Backspace
         this.amount = String(this.amount).slice(0, -1)
@@ -597,10 +597,7 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = true
-      this.keyboardTipCounter++
-      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
+      this.showKeyboardTooltip()
     },
     openCustomKeyboard (state) {
       this.readonlyState = state
@@ -1293,57 +1290,6 @@ export default {
         transform: none;
       }
     }
-  }
-
-  /* ==================== KEYBOARD TOOLTIP BUBBLE ==================== */
-  .keyboard-tooltip-bubble {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: calc(100% + 10px);
-    z-index: 10;
-    white-space: nowrap;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-size: 13px;
-    line-height: 1.4;
-    font-weight: 700;
-    pointer-events: none;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    animation: shake 0.4s ease-in-out;
-
-    &::after {
-      content: '';
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      border: 7px solid transparent;
-    }
-
-    &.dark {
-      background: #d32f2f;
-      color: #fff;
-
-      &::after {
-        border-top-color: #d32f2f;
-      }
-    }
-
-    &.light {
-      background: #e53935;
-      color: #fff;
-
-      &::after {
-        border-top-color: #e53935;
-      }
-    }
-  }
-
-  @keyframes shake {
-    0%, 100% { transform: translateX(-50%); }
-    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
   }
 
   /* ==================== SKELETON LOADER STYLES ==================== */

--- a/src/pages/apps/exchange/peer_to_peer/order-form.vue
+++ b/src/pages/apps/exchange/peer_to_peer/order-form.vue
@@ -576,8 +576,8 @@ export default {
             }
           } else {
             finalAmount += key !== '.' ? key.toString() : ''
+          }
         }
-      }
       }
       this.shiftAmount = 0
       this.amount = finalAmount

--- a/src/pages/apps/exchange/peer_to_peer/order-form.vue
+++ b/src/pages/apps/exchange/peer_to_peer/order-form.vue
@@ -111,7 +111,7 @@
               </div>
 
               <!-- Input Card -->
-              <div class="pt-card q-pa-md q-mb-md br-15" :class="darkMode ? 'dark' : 'light'" v-if="!isOwner">
+              <div class="pt-card q-pa-md q-mb-md br-15" :class="darkMode ? 'dark' : 'light'" v-if="!isOwner" style="position: relative;">
                 <!-- <div class="xs-font-size subtext q-pb-xs q-pl-sm">Amount</div> -->
                 <q-input
                   class="q-pb-xs"
@@ -133,7 +133,7 @@
                     <span>{{ byFiat ? ad?.fiat_currency?.symbol : 'BCH' }}</span>
                   </template>
                 </q-input>
-                <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+                <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
                   {{ $t('PleaseUseCustomKeyboard') }}
                 </div>
                 <div class="row justify-between">
@@ -331,6 +331,8 @@ export default {
       minHeight: this.$q.platform.is.ios ? this.$q.screen.height - (90 + 120) : this.$q.screen.height - (70 + 100),
       customKeyboardState: 'dismiss',
       showKeyboardTooltip: false,
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
       readonlyState: false,
       ad: null,
       state: 'initial',
@@ -571,12 +573,16 @@ export default {
             }
           } else {
             finalAmount += key !== '.' ? key.toString() : ''
+        }
+      }
       }
       this.shiftAmount = 0
       this.amount = finalAmount
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
     },
     makeKeyAction (action) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       if (action === 'backspace') {
         // Backspace
@@ -591,7 +597,10 @@ export default {
     },
     onKeyboardInput (e) {
       e.preventDefault()
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = true
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
     },
     openCustomKeyboard (state) {
       this.readonlyState = state
@@ -1284,6 +1293,57 @@ export default {
         transform: none;
       }
     }
+  }
+
+  /* ==================== KEYBOARD TOOLTIP BUBBLE ==================== */
+  .keyboard-tooltip-bubble {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(100% + 10px);
+    z-index: 10;
+    white-space: nowrap;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    font-weight: 700;
+    pointer-events: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    animation: shake 0.4s ease-in-out;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 7px solid transparent;
+    }
+
+    &.dark {
+      background: #d32f2f;
+      color: #fff;
+
+      &::after {
+        border-top-color: #d32f2f;
+      }
+    }
+
+    &.light {
+      background: #e53935;
+      color: #fff;
+
+      &::after {
+        border-top-color: #e53935;
+      }
+    }
+  }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(-50%); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
   }
 
   /* ==================== SKELETON LOADER STYLES ==================== */

--- a/src/pages/apps/exchange/peer_to_peer/order-form.vue
+++ b/src/pages/apps/exchange/peer_to_peer/order-form.vue
@@ -126,12 +126,16 @@
                   v-model="amount"
                   @blur="resetInput"
                   @focus="openCustomKeyboard(true)"
+                  @keydown="onKeyboardInput"
                   :readonly="readonlyState"
                   >
                   <template v-slot:append>
                     <span>{{ byFiat ? ad?.fiat_currency?.symbol : 'BCH' }}</span>
                   </template>
                 </q-input>
+                <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+                  {{ $t('PleaseUseCustomKeyboard') }}
+                </div>
                 <div class="row justify-between">
                   <div v-if="amountError" class="col text-left text-weight-bold subtext sm-font-size q-pl-sm text-red">
                     {{ amountError }}
@@ -326,6 +330,7 @@ export default {
       isloaded: false,
       minHeight: this.$q.platform.is.ios ? this.$q.screen.height - (90 + 120) : this.$q.screen.height - (70 + 100),
       customKeyboardState: 'dismiss',
+      showKeyboardTooltip: false,
       readonlyState: false,
       ad: null,
       state: 'initial',
@@ -566,12 +571,13 @@ export default {
             }
           } else {
             finalAmount += key !== '.' ? key.toString() : ''
-          }
-        }
-        this.amount = finalAmount
       }
+      this.shiftAmount = 0
+      this.amount = finalAmount
+      this.showKeyboardTooltip = false
     },
     makeKeyAction (action) {
+      this.showKeyboardTooltip = false
       if (action === 'backspace') {
         // Backspace
         this.amount = String(this.amount).slice(0, -1)
@@ -582,6 +588,10 @@ export default {
         this.customKeyboardState = 'dismiss'
         this.readonlyState = false
       }
+    },
+    onKeyboardInput (e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
     },
     openCustomKeyboard (state) {
       this.readonlyState = state

--- a/src/pages/apps/gifts/create-gift.vue
+++ b/src/pages/apps/gifts/create-gift.vue
@@ -199,6 +199,7 @@
                     type="text"
                     v-model="giftAmountFormatted"
                     @focus="onAmountInputFocus"
+                    @keydown="onKeyboardInput"
                     :dark="darkMode"
                     hide-bottom-space
                   >
@@ -207,6 +208,9 @@
                       <q-icon name="mdi-chevron-down" size="20px" class="denomination-arrow" />
                     </template>
                   </q-input>
+                  <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+                    {{ $t('PleaseUseCustomKeyboard') }}
+                  </div>
                 </div>
                 
                 <div class="row items-center justify-between q-mt-sm">
@@ -500,6 +504,7 @@ export default {
       giftStatus: null,
       failedGiftDetails: null,
       customKeyboardState: 'dismiss',
+      showKeyboardTooltip: false,
       savingGiftQR: false
     }
   },
@@ -1445,7 +1450,12 @@ export default {
     onAmountInputFocus() {
       this.customKeyboardState = 'show'
     },
+    onKeyboardInput(e) {
+      e.preventDefault()
+      this.showKeyboardTooltip = true
+    },
     setAmount(key) {
+      this.showKeyboardTooltip = false
       // Get current caret position, default to end of string
       const caret = this.$refs.amountInput?.nativeEl?.selectionStart ?? String(this.giftAmount).length
 
@@ -1469,6 +1479,7 @@ export default {
       }
     },
     makeKeyAction(action) {
+      this.showKeyboardTooltip = false
       if (action === 'backspace') {
         try {
           const amountStr = String(this.giftAmount || '')

--- a/src/pages/apps/gifts/create-gift.vue
+++ b/src/pages/apps/gifts/create-gift.vue
@@ -208,7 +208,7 @@
                       <q-icon name="mdi-chevron-down" size="20px" class="denomination-arrow" />
                     </template>
                   </q-input>
-                  <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+                  <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
                     {{ $t('PleaseUseCustomKeyboard') }}
                   </div>
                 </div>
@@ -504,6 +504,8 @@ export default {
       giftStatus: null,
       failedGiftDetails: null,
       customKeyboardState: 'dismiss',
+      keyboardTipTimer: null,
+      keyboardTipCounter: 0,
       showKeyboardTooltip: false,
       savingGiftQR: false
     }
@@ -1452,9 +1454,13 @@ export default {
     },
     onKeyboardInput(e) {
       e.preventDefault()
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = true
+      this.keyboardTipCounter++
+      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
     },
     setAmount(key) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       // Get current caret position, default to end of string
       const caret = this.$refs.amountInput?.nativeEl?.selectionStart ?? String(this.giftAmount).length
@@ -1479,6 +1485,7 @@ export default {
       }
     },
     makeKeyAction(action) {
+      clearTimeout(this.keyboardTipTimer)
       this.showKeyboardTooltip = false
       if (action === 'backspace') {
         try {
@@ -2053,7 +2060,51 @@ export default {
 }
 
 // Responsive
-@media (max-width: 600px) {
+  .keyboard-tooltip-bubble {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(100% + 10px);
+    z-index: 10;
+    white-space: nowrap;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    font-weight: 700;
+    pointer-events: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    animation: shake 0.4s ease-in-out;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 7px solid transparent;
+    }
+
+    &.dark {
+      background: #d32f2f;
+      color: #fff;
+      &::after { border-top-color: #d32f2f; }
+    }
+
+    &.light {
+      background: #e53935;
+      color: #fff;
+      &::after { border-top-color: #e53935; }
+    }
+  }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(-50%); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
+  }
+
+  @media (max-width: 600px) {
   .form-card,
   .success-card,
   .processing-card {

--- a/src/pages/apps/gifts/create-gift.vue
+++ b/src/pages/apps/gifts/create-gift.vue
@@ -208,9 +208,7 @@
                       <q-icon name="mdi-chevron-down" size="20px" class="denomination-arrow" />
                     </template>
                   </q-input>
-                  <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="getDarkModeClass(darkMode)" :key="keyboardTipCounter">
-                    {{ $t('PleaseUseCustomKeyboard') }}
-                  </div>
+                  <KeyboardTooltip v-if="showTooltip" :dark-mode="darkMode" :key="'tip-' + tipCounter" />
                 </div>
                 
                 <div class="row items-center justify-between q-mt-sm">
@@ -464,6 +462,8 @@ import SaveToGallery from 'src/utils/save-to-gallery'
 import paytacaLogoHorizontal from '../../../assets/paytaca_logo_horizontal.png'
 import { hexToRef } from 'src/utils/reference-id-utils'
 import { showLimitDialogWithDeps } from 'src/composables/useTieredLimitGate'
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
+import { useKeyboardTooltip } from 'src/composables/useKeyboardTooltip'
 
 const aesjs = require('aes-js')
 const short = require('short-uuid')
@@ -472,7 +472,12 @@ const sss = require('shamirs-secret-sharing')
 
 export default {
   name: 'Gifts',
+  setup () {
+    const { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip } = useKeyboardTooltip()
+    return { showTooltip, tipCounter, showKeyboardTooltip, hideKeyboardTooltip }
+  },
   components: {
+    KeyboardTooltip,
     HeaderNav,
     ProgressLoader,
     ShareGiftPanel,
@@ -504,9 +509,6 @@ export default {
       giftStatus: null,
       failedGiftDetails: null,
       customKeyboardState: 'dismiss',
-      keyboardTipTimer: null,
-      keyboardTipCounter: 0,
-      showKeyboardTooltip: false,
       savingGiftQR: false
     }
   },
@@ -1454,14 +1456,10 @@ export default {
     },
     onKeyboardInput(e) {
       e.preventDefault()
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = true
-      this.keyboardTipCounter++
-      this.keyboardTipTimer = setTimeout(() => { this.showKeyboardTooltip = false }, 10000)
+      this.showKeyboardTooltip()
     },
     setAmount(key) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       // Get current caret position, default to end of string
       const caret = this.$refs.amountInput?.nativeEl?.selectionStart ?? String(this.giftAmount).length
 
@@ -1485,8 +1483,7 @@ export default {
       }
     },
     makeKeyAction(action) {
-      clearTimeout(this.keyboardTipTimer)
-      this.showKeyboardTooltip = false
+      this.hideKeyboardTooltip()
       if (action === 'backspace') {
         try {
           const amountStr = String(this.giftAmount || '')
@@ -2058,51 +2055,6 @@ export default {
     }
   }
 }
-
-// Responsive
-  .keyboard-tooltip-bubble {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: calc(100% + 10px);
-    z-index: 10;
-    white-space: nowrap;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-size: 13px;
-    line-height: 1.4;
-    font-weight: 700;
-    pointer-events: none;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    animation: shake 0.4s ease-in-out;
-
-    &::after {
-      content: '';
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      border: 7px solid transparent;
-    }
-
-    &.dark {
-      background: #d32f2f;
-      color: #fff;
-      &::after { border-top-color: #d32f2f; }
-    }
-
-    &.light {
-      background: #e53935;
-      color: #fff;
-      &::after { border-top-color: #e53935; }
-    }
-  }
-
-  @keyframes shake {
-    0%, 100% { transform: translateX(-50%); }
-    10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-    20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-  }
 
   @media (max-width: 600px) {
   .form-card,

--- a/src/pages/apps/multisig/wallet/transaction/send.vue
+++ b/src/pages/apps/multisig/wallet/transaction/send.vue
@@ -144,9 +144,7 @@
                           :ref="el => { if (el) amountInputRefs[i] = el }"
                           >
                         </q-input>
-                        <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
-                          {{ $t('PleaseUseCustomKeyboard') }}
-                        </div>
+                        <KeyboardTooltip v-if="keyboardTipRecipientIndex === i" :dark-mode="darkMode" :key="'tip-' + keyboardTipCounter" />
                       </q-item-label>
                       <q-separator class="q-my-sm"/>
                     </q-item-section>
@@ -201,7 +199,7 @@
 
 import { useStore } from 'vuex'
 import { useI18n } from 'vue-i18n'
-import { computed, onMounted, ref, nextTick, onBeforeMount, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, nextTick, onBeforeMount, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuasar } from 'quasar'
 import Big from 'big.js'
@@ -214,6 +212,7 @@ import {
   MultisigWallet,
 } from 'src/lib/multisig'
 import CustomKeyboard from 'src/components/CustomKeyboard.vue'
+import KeyboardTooltip from 'src/components/KeyboardTooltip.vue'
 import { useMultisigHelpers } from 'src/composables/multisig/helpers'
 import { decodeCashAddress } from 'bitauth-libauth-v3'
 import { generateCosignerAuthPublicKeyFromXpub } from 'src/lib/multisig/coordination'
@@ -266,7 +265,7 @@ const showWcHeldFundsDialog = ref(false)
 const reserveWcAccountUtxos = ref(true)
 const showQrScanner = ref(false)
 const currentRecipientIndex = ref(null)
-const showKeyboardTooltip = ref(false)
+const keyboardTipRecipientIndex = ref(null)
 const keyboardTipTimer = ref(null)
 const keyboardTipCounter = ref(0)
 const customKeyboardState = ref('dismiss')
@@ -473,14 +472,14 @@ const asset = computed(() => {
 const onKeydown = (e) => {
   e.preventDefault()
   clearTimeout(keyboardTipTimer.value)
-  showKeyboardTooltip.value = true
+  keyboardTipRecipientIndex.value = currentRecipientIndex.value
   keyboardTipCounter.value++
-  keyboardTipTimer.value = setTimeout(() => { showKeyboardTooltip.value = false }, 10000)
+  keyboardTipTimer.value = setTimeout(() => { keyboardTipRecipientIndex.value = null }, 10000)
 }
 
 const setAmount = (amount) => {
   clearTimeout(keyboardTipTimer.value)
-  showKeyboardTooltip.value = false
+  keyboardTipRecipientIndex.value = null
   if (focusedInputField.value !== 'amount') return
   const recipient = recipients.value[currentRecipientIndex.value]
   if (!recipient) return
@@ -489,7 +488,7 @@ const setAmount = (amount) => {
 
 const makeKeyAction = (action) => {
   clearTimeout(keyboardTipTimer.value)
-  showKeyboardTooltip.value = false
+  keyboardTipRecipientIndex.value = null
   if (focusedInputField.value !== 'amount') return
   const recipient = recipients.value[currentRecipientIndex.value]
   if (!recipient) return
@@ -648,6 +647,10 @@ onMounted(async () => {
   await wallet.value.subscribeWalletAddressIndex(wallet.value.getLastUsedChangeAddressIndex(network) + 1, 'change')
   purpose.value = `${$t('Send')} ${assetHeaderName.value}`
 })
+
+onUnmounted(() => {
+  clearTimeout(keyboardTipTimer.value)
+})
 </script>
 
 <style scoped>
@@ -673,47 +676,5 @@ onMounted(async () => {
   height: 100px;
 }
 
-.keyboard-tooltip-bubble {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  bottom: calc(100% + 10px);
-  z-index: 10;
-  white-space: nowrap;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 13px;
-  line-height: 1.4;
-  font-weight: 700;
-  pointer-events: none;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-  animation: shake 0.4s ease-in-out;
 
-  &::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 7px solid transparent;
-  }
-
-  &.dark {
-    background: #d32f2f;
-    color: #fff;
-    &::after { border-top-color: #d32f2f; }
-  }
-
-  &.light {
-    background: #e53935;
-    color: #fff;
-    &::after { border-top-color: #e53935; }
-  }
-}
-
-@keyframes shake {
-  0%, 100% { transform: translateX(-50%); }
-  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
-  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
-}
 </style>

--- a/src/pages/apps/multisig/wallet/transaction/send.vue
+++ b/src/pages/apps/multisig/wallet/transaction/send.vue
@@ -112,7 +112,7 @@
                   </q-item>
                   <q-item v-for="recipient,i in recipients" :key="`recipient-${i}`" :ref="el => { if (el) recipientRefs[i] = el.$el || el }">
                     <q-item-section>
-                      <q-item-label :class="addressInputRefs[i]? 'q-gutter-y-md': ''">
+                      <q-item-label style="position: relative;" :class="addressInputRefs[i]? 'q-gutter-y-md': ''">
                         <div class="flex justify-between items-center">
                             <span class="text-italic">{{ $t('RecipientLabel') }} {{ i + 1 }}</span>
                             <q-btn v-if="i > 0" @click="removeRecipient(i)" icon="remove" color="red" flat dense :disable="isCreatingProposal"></q-btn>
@@ -144,7 +144,7 @@
                           :ref="el => { if (el) amountInputRefs[i] = el }"
                           >
                         </q-input>
-                        <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+                        <div v-if="showKeyboardTooltip" class="keyboard-tooltip-bubble" :class="darkMode ? 'dark' : 'light'" :key="keyboardTipCounter">
                           {{ $t('PleaseUseCustomKeyboard') }}
                         </div>
                       </q-item-label>
@@ -267,6 +267,8 @@ const reserveWcAccountUtxos = ref(true)
 const showQrScanner = ref(false)
 const currentRecipientIndex = ref(null)
 const showKeyboardTooltip = ref(false)
+const keyboardTipTimer = ref(null)
+const keyboardTipCounter = ref(0)
 const customKeyboardState = ref('dismiss')
 const focusedInputField = ref('')
 
@@ -470,10 +472,14 @@ const asset = computed(() => {
 
 const onKeydown = (e) => {
   e.preventDefault()
+  clearTimeout(keyboardTipTimer.value)
   showKeyboardTooltip.value = true
+  keyboardTipCounter.value++
+  keyboardTipTimer.value = setTimeout(() => { showKeyboardTooltip.value = false }, 10000)
 }
 
 const setAmount = (amount) => {
+  clearTimeout(keyboardTipTimer.value)
   showKeyboardTooltip.value = false
   if (focusedInputField.value !== 'amount') return
   const recipient = recipients.value[currentRecipientIndex.value]
@@ -482,6 +488,7 @@ const setAmount = (amount) => {
 }
 
 const makeKeyAction = (action) => {
+  clearTimeout(keyboardTipTimer.value)
   showKeyboardTooltip.value = false
   if (focusedInputField.value !== 'amount') return
   const recipient = recipients.value[currentRecipientIndex.value]
@@ -664,5 +671,49 @@ onMounted(async () => {
 
 .sticky-bottom-spacer {
   height: 100px;
+}
+
+.keyboard-tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(100% + 10px);
+  z-index: 10;
+  white-space: nowrap;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 700;
+  pointer-events: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  animation: shake 0.4s ease-in-out;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 7px solid transparent;
+  }
+
+  &.dark {
+    background: #d32f2f;
+    color: #fff;
+    &::after { border-top-color: #d32f2f; }
+  }
+
+  &.light {
+    background: #e53935;
+    color: #fff;
+    &::after { border-top-color: #e53935; }
+  }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(-50%); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(calc(-50% - 4px)); }
+  20%, 40%, 60%, 80% { transform: translateX(calc(-50% + 4px)); }
 }
 </style>

--- a/src/pages/apps/multisig/wallet/transaction/send.vue
+++ b/src/pages/apps/multisig/wallet/transaction/send.vue
@@ -140,9 +140,13 @@
                           :disable="isCreatingProposal"
                           inputmode="none"
                           @focus="onAmountFocus(i)"
+                          @keydown="onKeydown"
                           :ref="el => { if (el) amountInputRefs[i] = el }"
                           >
                         </q-input>
+                        <div v-if="showKeyboardTooltip" class="text-caption text-negative q-mt-xs">
+                          {{ $t('PleaseUseCustomKeyboard') }}
+                        </div>
                       </q-item-label>
                       <q-separator class="q-my-sm"/>
                     </q-item-section>
@@ -262,6 +266,7 @@ const showWcHeldFundsDialog = ref(false)
 const reserveWcAccountUtxos = ref(true)
 const showQrScanner = ref(false)
 const currentRecipientIndex = ref(null)
+const showKeyboardTooltip = ref(false)
 const customKeyboardState = ref('dismiss')
 const focusedInputField = ref('')
 
@@ -463,7 +468,13 @@ const asset = computed(() => {
   }
 })
 
+const onKeydown = (e) => {
+  e.preventDefault()
+  showKeyboardTooltip.value = true
+}
+
 const setAmount = (amount) => {
+  showKeyboardTooltip.value = false
   if (focusedInputField.value !== 'amount') return
   const recipient = recipients.value[currentRecipientIndex.value]
   if (!recipient) return
@@ -471,6 +482,7 @@ const setAmount = (amount) => {
 }
 
 const makeKeyAction = (action) => {
+  showKeyboardTooltip.value = false
   if (focusedInputField.value !== 'amount') return
   const recipient = recipients.value[currentRecipientIndex.value]
   if (!recipient) return


### PR DESCRIPTION
## Summary

When the custom numeric keypad is active, physical keyboard input should be blocked since the custom keyboard is the intended input method. This PR implements that blocking behavior and adds a clear tooltip to inform users to use the custom keyboard instead.

## Changes

### 1. Block native keyboard input
Added `@keydown.preventDefault()` on all `q-input` fields linked to a `CustomKeyboard`. When a user presses a key on the device keyboard, the input is suppressed and a tooltip message appears.

### 2. Redesigned tooltip
The "Please use the custom keyboard" tooltip was redesigned from a plain red text line that pushed layout around into a prominent floating bubble:

- **Floating bubble**: Positioned above the input with a downward-pointing arrow — no layout shift
- **High-visibility**: Bold red background with white text, strong shadow
- **Shake animation**: Each subsequent keypress shakes the tooltip to reinforce the message
- **Auto-hide**: Automatically dismisses after 10 seconds
- **Per-input tracking**: Field-specific tracking prevents duplicate tooltips on screens with multiple inputs

### 3. Bug fixes
- Fixed unmatched `</div>` in `SendPageForm.vue`
- Fixed missing closing brace in `order-form.vue` `setAmount` function

## Files affected (11 files, ~700 lines changed)

All Vue components that use the custom keyboard:

- `CustomKeyboardInput.vue` — wrapper component
- `CustomInput.vue` — wrapper component
- `SendPageForm.vue` — send page
- `order-form.vue` — P2P order form
- `create-gift.vue` — gift creation
- `multisig/wallet/transaction/send.vue` — multisig send
- `RedeemPointsDialog.vue` — rewards redemption
- `FilterSelectionDialog.vue` — store filter dialog
- `CreateHedgeForm.vue` — anyhedge form
- `RampShiftForm.vue` — crypto ramp form
- `i18n/en-us/index.js` — added translation key