### PR TITLE
fix: refresh fiat prices for all displayed tokens, not just favorites

### DIFF
--- a/src/pages/transaction/index.vue
+++ b/src/pages/transaction/index.vue
@@ -1461,7 +1461,7 @@ export default {
         await this.refreshFavoriteTokenBalances()
         
         // Refresh prices for all favorite tokens + BCH
-        await this.refreshFavoriteTokenPrices()
+        await this.refreshDisplayedTokenPrices()
         
         // Refresh transaction list
         if (this.$refs['transaction-list-component']) {
@@ -1952,25 +1952,19 @@ export default {
         return Promise.resolve()
       }
     },
-    async refreshFavoriteTokenPrices() {
+    async refreshDisplayedTokenPrices() {
       const vm = this
       try {
-        // Always use API data only - never use Vuex store for favorite tokens
-        let favoriteTokenIds = []
-        
-        if (vm.isCashToken) {
-          // Use token IDs from API data - filter favorites from allTokensFromAPI
-          const favorites = (vm.allTokensFromAPI || []).filter(token => token.favorite === 1 || token.favorite === true)
-          favoriteTokenIds = favorites.map(token => token.id).filter(Boolean)
-        } else {
-          const favorites = (vm.allSlpTokensFromAPI || []).filter(token => token.favorite === 1 || token.favorite === true)
-          favoriteTokenIds = favorites.map(token => token.id).filter(Boolean)
-        }
+        // Refresh prices only for tokens actually displayed in the cards
+        // this.assets returns sortedTokens.slice(0, limit) — the visible subset
+        const displayedTokenIds = (vm.assets || [])
+          .map(token => token.id)
+          .filter(id => id && id !== 'bch')
 
         // Always include BCH (id: 'bch')
-        const tokensToRefresh = [...new Set([...favoriteTokenIds, 'bch'])]
+        const tokensToRefresh = [...new Set([...displayedTokenIds, 'bch'])]
 
-        // Refresh prices for all favorite tokens + BCH using unified API
+        // Refresh prices for all displayed tokens + BCH using unified API
         const pricePromises = tokensToRefresh.map(assetId => {
           return vm.$store.dispatch('market/updateAssetPrices', {
             assetId: assetId,
@@ -1983,7 +1977,7 @@ export default {
 
         return Promise.allSettled(pricePromises)
       } catch (error) {
-        console.error('Error refreshing favorite token prices:', error)
+        console.error('Error refreshing displayed token prices:', error)
         return Promise.resolve()
       }
     },
@@ -2491,7 +2485,7 @@ export default {
         if (!existingBchPrice) {
           vm.loadingBchPrice = true
         }
-        vm.refreshFavoriteTokenPrices()
+        vm.refreshDisplayedTokenPrices()
           .then(() => {
             vm.loadingBchPrice = false
           })


### PR DESCRIPTION
## Summary

- Previously, only **favorite** token prices were refreshed on page load and pull-to-refresh, via `refreshFavoriteTokenPrices()`. Non-favorite tokens that appear in the token cards (up to the subscription limit) relied on stale prices left in the store from a prior dialog opening or an older fetch.
- On double-click, the AssetInfo dialog calls `updateAssetPrices({ assetId })` which fetches a **fresh** price, so the dialog always shows the correct fiat value — while the card may show a stale (smaller) value.
- The fix renames `refreshFavoriteTokenPrices` to `refreshDisplayedTokenPrices` and sources token IDs from `vm.assets` (the computed that drives the visible cards) instead of filtering to favorites only.

## Changes

`src/pages/transaction/index.vue`:
- `refreshFavoriteTokenPrices()` → `refreshDisplayedTokenPrices()` — uses `vm.assets` (sorted + limited to subscription tier) to get token IDs for price refresh
- Updated both callers: `onRefresh` (pull-to-refresh) and the on-mount price load