### PR TITLE
fix: gray out trailing zeros in BCH all-zero decimals; adaptive receipt font-size

### DIFF
--- a/src/directives/bch-amount.js
+++ b/src/directives/bch-amount.js
@@ -43,6 +43,7 @@ function applyGrayZeros(el, binding) {
   // Matches: "0.91801000 BCH" -> gray the "000"
   // Matches: "0.91801000" -> gray the "000" (no BCH symbol)
   // Matches: "1,234.56780000" -> gray the "000"
+  // Matches: "0.00000000" -> gray all "00000000" (no non-zero digits)
   // Does NOT match: "100 BCH" (no decimal)
   // Does NOT match: "1000.12345678" (no trailing zeros)
   // Does NOT match: "1.09453099" (the 0 is not trailing, there's a 9 after it)
@@ -58,7 +59,8 @@ function applyGrayZeros(el, binding) {
   const rest = parts.slice(1).join('');
   
   // Check if the number ends with zeros after decimal point
-  const pattern = /^([\d,\s]*\.\d*?[1-9])(0+)$/;
+  // Optional non-zero digit part handles "0.00000000" (all zeros)
+  const pattern = /^([\d,\s]*\.(?:\d*?[1-9])?)(0+)$/;
   const match = numberPart.match(pattern);
   
   if (!match) {

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -2279,12 +2279,15 @@ export default {
         typeLabel.textContent = isReceived ? 'Received' : 'Sent'
         amountContainer.appendChild(typeLabel)
 
+        const amountLen = amount.length
+        const amtFontSize = amountLen > 18 ? 28 : amountLen > 15 ? 34 : amountLen > 12 ? 42 : 48
         const amountValue = document.createElement('div')
         amountValue.style.cssText = `
-          font-size: 48px;
+          font-size: ${amtFontSize}px;
           font-weight: 800;
           color: white;
           letter-spacing: -1px;
+          white-space: nowrap;
           margin-bottom: ${fiatAmount ? '12px' : '0'};
         `
         amountValue.textContent = amount


### PR DESCRIPTION
## Summary

- **bch-amount directive**: Made the regex non-zero-digit part optional so `0.00000000` correctly grays out all trailing zeros (previously only worked when there was a non-zero digit before the zeros)
- **Receipt generation**: BCH amount font-size now scales down for long amounts (48px → 42/34/28px) to keep `amount BCH` on one line. Added `white-space: nowrap` as safety net.