### PR TITLE
Fix/wc message signer

### DIFF
--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1378,12 +1378,16 @@ const respondToSignMessageRequest = async (sessionRequest) => {
   try {
     const connectedAddressForTopic = sessionTopicWalletAddressMapping.value[sessionRequest.topic]
     if (!connectedAddressForTopic?.address) {
-      // response.error = { code: -32603, message: 'Account has no active session' }
       throw new Error('Account has no active session')
     }
+    const expectedAccount = sessionRequest.session?.namespaces?.bch?.accounts?.[0]
+    const expectedSignerAddress = expectedAccount ? expectedAccount.replace('bch:', '') : ''
+    if (expectedSignerAddress && expectedSignerAddress !== connectedAddressForTopic.address) {
+      throw new Error(`Expected signing address doesn't match session address`)
+    }
+
     const message = sessionRequest.params?.request?.params?.message
     if (message == undefined) {
-      // response.error = { code: -32603, message: 'Message parameter is mandatory' }
       throw new Error('Message parameter is mandatory')
     }
     response.result = signMessage(message, connectedAddressForTopic.wif)

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1395,7 +1395,7 @@ const respondToSignMessageRequest = async (sessionRequest) => {
   } catch (err) {
     response.error = {
       code: -32603,
-      message: err?.name === 'SignBCHTransactionError' ? err?.message : 'Unknown error'
+      message: err?.message || 'Unknown error'
     }
     sessionRequest.error = true
     processingSession.value[sessionRequest.topic] = 'Sending error response'

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1376,19 +1376,19 @@ const respondToSignMessageRequest = async (sessionRequest) => {
   if (!['personal_sign', 'bch_signMessage'].includes(sessionRequest.params.request.method)) return
   const response = { id: sessionRequest.id, jsonrpc: '2.0', result: undefined, error: undefined }
   try {
-    const signingAddress = sessionRequest.params?.request?.params?.account
     const connectedAddressForTopic = sessionTopicWalletAddressMapping.value[sessionRequest.topic]
-    if (!connectedAddressForTopic?.address || signingAddress !== connectedAddressForTopic.address) {
-      response.error = { code: -32603, message: 'Account has no active session' }
+    if (!connectedAddressForTopic?.address) {
+      // response.error = { code: -32603, message: 'Account has no active session' }
+      throw new Error('Account has no active session')
     }
     const message = sessionRequest.params?.request?.params?.message
     if (message == undefined) {
-      response.error = { code: -32603, message: 'Message parameter is mandatory' }
+      // response.error = { code: -32603, message: 'Message parameter is mandatory' }
+      throw new Error('Message parameter is mandatory')
     }
     response.result = await signMessage(message, connectedAddressForTopic.wif)
     processingSession.value[sessionRequest.topic] = 'Confirming request'
   } catch (err) {
-    console.error('🚀 ~ respondToSignMessageRequest ~ err:', err)
     response.error = {
       code: -32603,
       message: err?.name === 'SignBCHTransactionError' ? err?.message : 'Unknown error'

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1386,7 +1386,7 @@ const respondToSignMessageRequest = async (sessionRequest) => {
       // response.error = { code: -32603, message: 'Message parameter is mandatory' }
       throw new Error('Message parameter is mandatory')
     }
-    response.result = await signMessage(message, connectedAddressForTopic.wif)
+    response.result = signMessage(message, connectedAddressForTopic.wif)
     processingSession.value[sessionRequest.topic] = 'Confirming request'
   } catch (err) {
     response.error = {

--- a/src/wallet/walletconnect2/index.js
+++ b/src/wallet/walletconnect2/index.js
@@ -350,12 +350,12 @@ export function signMessage(message, wif='') {
       throw new Error(`Invalid WIF: ${decodedPrivateKeyWif}`);
     }
     const privateKey = decodedPrivateKeyWif.privateKey;
-    const isCompressed = decodedPrivateKeyWif.type === 'mainnet' || decodedPrivateKeyWif.type === 'testnet'; 
     
+    const isCompressed = !decodedPrivateKeyWif.type.endsWith('Uncompressed'); 
     const prefixStr = "Bitcoin Signed Message:\n";
     const prefixBin = utf8ToBin(prefixStr);
+    // Intentionally hardcoding length for hardcoded prefixStr, will change if refactored using dynamic prefix.
     const prefixLenBin = new Uint8Array([0x18]); 
-    
     const messageBin = utf8ToBin(message);
     const messageLenBin = bigIntToCompactUint(BigInt(messageBin.length));
   
@@ -369,6 +369,9 @@ export function signMessage(message, wif='') {
     const preImageHash = hash256(preImage);
     // Note: Standard Bitcoin message signing historically relies strictly on ECDSA.
     const sigObj = secp256k1.signMessageHashRecoverableCompact(privateKey, preImageHash);
+    if (typeof sigObj === 'string') {
+      throw new Error(`Signing failed: ${sigObj}`);
+    }
     // Legacy format requires adding 27 for uncompressed keys, 31 for compressed keys
     const headerByte = sigObj.recoveryId + (isCompressed ? 31 : 27);
     const compactSignature = new Uint8Array([headerByte, ...sigObj.signature]);

--- a/src/wallet/walletconnect2/index.js
+++ b/src/wallet/walletconnect2/index.js
@@ -1,8 +1,12 @@
 import {
+  bigIntToCompactUint,
+  binToBase64,
   binToHex,
   decodePrivateKeyWif,
   lockingBytecodeToCashAddress,
   secp256k1,
+  utf8ToBin,
+  hash256,
 } from 'bitauth-libauth-v3'
 import { Core } from '@walletconnect/core'
 import { WalletKit } from '@reown/walletkit'
@@ -340,9 +344,35 @@ export function parseSessionRequest(sessionRequest) {
   return parsedSessionRequest
 }
 
-export async function signMessage(message, wif='') {
-  const signatureBase64 = bchjs.BitcoinCash.signMessageWithPrivKey(wif, message)
-  return Buffer.from(signatureBase64, 'base64').toString('hex')
+export function signMessage(message, wif='') {
+    const decodedPrivateKeyWif = decodePrivateKeyWif(wif);
+    if (typeof decodedPrivateKeyWif === 'string') {
+      throw new Error(`Invalid WIF: ${decodedPrivateKeyWif}`);
+    }
+    const privateKey = decodedPrivateKeyWif.privateKey;
+    const isCompressed = decodedPrivateKeyWif.type === 'mainnet' || decodedPrivateKeyWif.type === 'testnet'; 
+    
+    const prefixStr = "Bitcoin Signed Message:\n";
+    const prefixBin = utf8ToBin(prefixStr);
+    const prefixLenBin = new Uint8Array([0x18]); 
+    
+    const messageBin = utf8ToBin(message);
+    const messageLenBin = bigIntToCompactUint(BigInt(messageBin.length));
+  
+    const preImage = new Uint8Array([
+      ...prefixLenBin,
+      ...prefixBin,
+      ...messageLenBin,
+      ...messageBin
+    ]);
+  
+    const preImageHash = hash256(preImage);
+    // Note: Standard Bitcoin message signing historically relies strictly on ECDSA.
+    const sigObj = secp256k1.signMessageHashRecoverableCompact(privateKey, preImageHash);
+    // Legacy format requires adding 27 for uncompressed keys, 31 for compressed keys
+    const headerByte = sigObj.recoveryId + (isCompressed ? 31 : 27);
+    const compactSignature = new Uint8Array([headerByte, ...sigObj.signature]);
+    return binToBase64(compactSignature);
 }
 
 export async function signBchTransaction(transaction, sourceOutputsUnpacked, wif='') {


### PR DESCRIPTION
## Description
Update message signer, replace message signer lib with libauth. Use legacy signing method for max compatibility. Return recoverable compact sig. Update message signer response format from hex to base64.

Fixes # (issue)
Message signing failure, (Buffer length error...) 

## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Test Notes
- Send sign message request from walletconnect connected dapp to the Paytaca wallet
- Sign message succeeds after applying the changes

## @mentions
@joemarct 
