### PR TITLE
fix: wallet file export/download on native mobile crashes app

### DIFF
--- a/src/pages/apps/multisig/wallet/import.vue
+++ b/src/pages/apps/multisig/wallet/import.vue
@@ -102,7 +102,7 @@ const onUpdateWalletFileModelValue = (file) => {
       })
     }
     reader.onerror = (err) => {
-      console.err(err)
+      console.error(err)
     }
     reader.readAsArrayBuffer(file)
   }

--- a/src/pages/apps/multisig/wallet/import.vue
+++ b/src/pages/apps/multisig/wallet/import.vue
@@ -82,8 +82,17 @@ const onUpdateWalletFileModelValue = (file) => {
   if (file) {
     const reader = new FileReader()
     reader.onload = () => {
-      const decoded = cborDecode(base64ToBin(reader.result))
-      console.log('DECODED', decoded)
+      const bin = new Uint8Array(reader.result)
+      let base64Data
+
+      const text = new TextDecoder().decode(bin)
+      if (/^[A-Za-z0-9+/]+=*$/.test(text.slice(0, 60))) {
+        base64Data = text
+      } else {
+        base64Data = btoa(String.fromCharCode(...bin))
+      }
+
+      const decoded = cborDecode(base64ToBin(base64Data))
       walletInstance.value = MultisigWallet.import(decoded)
       walletInstance.value.setStore($store)
       walletInstance.value.save()
@@ -95,7 +104,7 @@ const onUpdateWalletFileModelValue = (file) => {
     reader.onerror = (err) => {
       console.err(err)
     }
-    reader.readAsText(file)
+    reader.readAsArrayBuffer(file)
   }
 }
 

--- a/src/pages/apps/multisig/wallet/pst/view.vue
+++ b/src/pages/apps/multisig/wallet/pst/view.vue
@@ -531,7 +531,7 @@ const openFileDownloadDialog = ({dialogTitle, dialogMessage, defaultFilename, fi
           path: fullFilename,
           data: data, 
           directory: Directory.Cache,
-          encoding: 'utf8' 
+          encoding: 'base64' 
         });
 
         return await Share.share({

--- a/src/pages/apps/multisig/wallet/view.vue
+++ b/src/pages/apps/multisig/wallet/view.vue
@@ -334,7 +334,7 @@ import { Filesystem, Directory } from '@capacitor/filesystem';
 import { Share } from '@capacitor/share';
 import { Platform } from 'quasar';
 import Big from 'big.js'
-import { binToBase64, hexToBin, secp256k1, sortObjectKeys } from 'bitauth-libauth-v3'
+import { binToBase64, base64ToBin, hexToBin, secp256k1, sortObjectKeys } from 'bitauth-libauth-v3'
 import { cborEncode } from '@ngraveio/bc-ur/dist/cbor'
 import HeaderNav from 'components/header-nav'
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
@@ -544,7 +544,7 @@ const downloadWalletFile = async (walletToExport) => {
         path: fullFilename,
         data: data, 
         directory: Directory.Cache, 
-        encoding: 'utf8' 
+        encoding: 'base64' 
       });
 
       return await Share.share({
@@ -553,7 +553,7 @@ const downloadWalletFile = async (walletToExport) => {
       });
     } 
 
-    const blob = new Blob([data], { type: 'text/plain' })
+    const blob = new Blob([base64ToBin(data)], { type: 'application/octet-stream' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url


### PR DESCRIPTION
Description
Fixed a crash that occurred when exporting/downloading multisig wallet files on native mobile Android 11

Fixes # Fixed a crash that occurred when exporting/downloading multisig wallet files on native mobile Android 11
Screenshots (if applicable):
N/A — no UI changes

Type of Change
[] UI improvements with no business logic changes
[x] Bug fix (non-breaking change which fixes an issue)
[] New feature (non-breaking change which adds functionality)
[] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[] Documentation update

Test Notes
1. Successfully download wallet file on Android 11.

Changes are scoped to multisig wallet file I/O and should not affect other features.
@mentions