### PR TITLE
fix(@wizardconnect/wallet): prevent race condition during disconnect

### DIFF
--- a/patches/@wizardconnect+wallet+0.2.2.patch
+++ b/patches/@wizardconnect+wallet+0.2.2.patch
@@ -1,0 +1,57 @@
+diff --git a/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js b/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
+index 65729ae..13fa6a5 100644
+--- a/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
++++ b/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
+@@ -110,24 +110,44 @@ export class WalletConnectionManager extends EventEmitter {
+         }
+     }
+     doDisconnect(connectionId, sendMessage) {
++        console.log('doing disconnectz', sendMessage, connectionId)
+         const conn = this.connections.get(connectionId);
+         if (!conn)
+             return;
++
++        const clean = () => {
++            for (const seq of conn.signSequences) {
++                this.activeSignSequences.delete(seq);
++            }
++            clearInterval(conn.notificationProcessor ?? undefined);
++            conn.cleanup();
++            this.connections.delete(connectionId);
++            this.emit("connectionsChanged");
++        }
++
+         if (sendMessage && conn.client) {
+             const disconnectMsg = {
+                 action: RelayMsgAction.Disconnect,
+                 reason: DisconnectReason.UserDisconnect,
+                 time: Math.floor(Date.now() / 1000),
+             };
+-            conn.client.relay(disconnectMsg).catch(() => { });
++            conn.client.relay(disconnectMsg)
++                .then((res) => {
++                    clean()
++                })
++                .catch(() => { clean() });
++
++        } else {
++            clean()
+         }
+-        for (const seq of conn.signSequences) {
+-            this.activeSignSequences.delete(seq);
+-        }
+-        clearInterval(conn.notificationProcessor ?? undefined);
+-        conn.cleanup();
+-        this.connections.delete(connectionId);
+-        this.emit("connectionsChanged");
++
++        // for (const seq of conn.signSequences) {
++        //     this.activeSignSequences.delete(seq);
++        // }
++        // clearInterval(conn.notificationProcessor ?? undefined);
++        // conn.cleanup();
++        // this.connections.delete(connectionId);
++        // this.emit("connectionsChanged");
+     }
+     /**
+      * Get all connection states (for UI/Redux).

--- a/patches/@wizardconnect+wallet+0.2.2.patch
+++ b/patches/@wizardconnect+wallet+0.2.2.patch
@@ -1,13 +1,12 @@
 diff --git a/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js b/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
-index 65729ae..13fa6a5 100644
+index 65729ae..3a39ea7 100644
 --- a/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
 +++ b/node_modules/@wizardconnect/wallet/dist/wallet-connection-manager.js
-@@ -110,24 +110,44 @@ export class WalletConnectionManager extends EventEmitter {
-         }
+@@ -111,23 +111,35 @@ export class WalletConnectionManager extends EventEmitter {
      }
      doDisconnect(connectionId, sendMessage) {
-+        console.log('doing disconnectz', sendMessage, connectionId)
          const conn = this.connections.get(connectionId);
++
          if (!conn)
              return;
 +
@@ -44,14 +43,6 @@ index 65729ae..13fa6a5 100644
 -        conn.cleanup();
 -        this.connections.delete(connectionId);
 -        this.emit("connectionsChanged");
-+
-+        // for (const seq of conn.signSequences) {
-+        //     this.activeSignSequences.delete(seq);
-+        // }
-+        // clearInterval(conn.notificationProcessor ?? undefined);
-+        // conn.cleanup();
-+        // this.connections.delete(connectionId);
-+        // this.emit("connectionsChanged");
      }
      /**
       * Get all connection states (for UI/Redux).


### PR DESCRIPTION
- Fix a race condition where DApps missed wallet disconnect events.
- Resolve issue leaving DApps in a stale connected state.

## Description
- Fix a race condition where DApps missed wallet disconnect events.

Fixes # (issue)
- Resolve issue leaving DApps in a stale connected state even after wallet disconnects.

## Screenshots (if applicable):
N/A No UI Related changes


## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes

#### 1. Without Patch (Failure - Intermittent)
* **Action:** Repeatedly connect and disconnect the wallet across multiple browser sessions on Cashtokens Studio and Cauldron.
* **Expected Behavior:** dApps should consistently receive the disconnect event to be able to update the UI state.
* **Actual Result:** ⚠️ **UNSTABLE / FAIL.** Due to the timing-dependent nature of the race condition, the disconnect event occasionally fired correctly, but In the vast majority of runs, the 'disconnect' event seldom fires on the dapp.

#### 2. With Patch (Verification)
* **Action:** Apply the `@wizardconnect/wallet` patch. Connect wallet to Cashtokens Studio and Cauldron, then manually disconnect via the wallet interface.
* **Expected Behavior:** dApps should receive the event.
* **Actual Result:** 🟢 **PASSED.** Both dApps successfully receives the 'disconnect' event

## @mentions
@joemarct 
