### PR TITLE
Add safe inset bottom for fixed-bottom class

### DIFF
--- a/src/components/CustomKeyboard.vue
+++ b/src/components/CustomKeyboard.vue
@@ -120,7 +120,7 @@ export default {
 .pt-custom-keyboard-row {
   width: 100%;
   color: #515151;
-  padding-bottom: env(safe-area-inset-bottom, 0px)
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 .pt-key-num {
   height: 45px;

--- a/src/components/CustomKeyboard.vue
+++ b/src/components/CustomKeyboard.vue
@@ -110,7 +110,7 @@ export default {
   z-index: 9000;
 }
 .pt-keyboard-container {
-  height: 250px;
+  height: calc(250px + env(safe-area-inset-bottom, 0px));
   background: #fff;
 }
 .br-top-15 {
@@ -120,6 +120,7 @@ export default {
 .pt-custom-keyboard-row {
   width: 100%;
   color: #515151;
+  padding-bottom: env(safe-area-inset-bottom, 0px)
 }
 .pt-key-num {
   height: 45px;

--- a/src/css/shared.scss
+++ b/src/css/shared.scss
@@ -206,6 +206,10 @@ div#q-app:has(.sticky-header-container) {
   }
 }
 
+.fixed-bottom {
+  bottom: env(safe-area-inset-bottom, 0);
+}
+
 .bottom-card {
   @include bottom-card();
 }

--- a/src/layouts/MarketplaceLayout.vue
+++ b/src/layouts/MarketplaceLayout.vue
@@ -509,6 +509,7 @@ export default {
 <style scoped>
 .footer-panel {
   pointer-events: none;
+  bottom: env(safe-area-inset-bottom, 0px);
 }
 .footer-panel * {
   pointer-events: auto;

--- a/src/layouts/MarketplaceLayout.vue
+++ b/src/layouts/MarketplaceLayout.vue
@@ -509,7 +509,6 @@ export default {
 <style scoped>
 .footer-panel {
   pointer-events: none;
-  bottom: env(safe-area-inset-bottom, 0px);
 }
 .footer-panel * {
   pointer-events: auto;


### PR DESCRIPTION
## Description
- Fixed cart button in marketplace not having proper spacing at the bottom
- Fixed order chat button in marketplace not having proper spacing at the bottom
- Fixed payment dialogs in marketplace checkout not having proper spacing at the bottom
- Added safe inset padding to custom keyboard

## Screenshots (if applicable):
<img width="335" height="706" alt="image" src="https://github.com/user-attachments/assets/8373b110-7caf-44ea-a366-43cef11e1419" />
<img width="336" height="431" alt="image" src="https://github.com/user-attachments/assets/9817bd9f-beb1-4606-a232-448b8f995e35" />
<img width="345" height="264" alt="image" src="https://github.com/user-attachments/assets/ec2292ca-128b-426a-a99b-c42d67ab196e" />
<img width="340" height="434" alt="image" src="https://github.com/user-attachments/assets/84f6deab-2fd1-42d1-a43d-e6489255b753" />




## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested on iphone device simulator with `safe-area-inset-bottom`, checked ui if proper spacing is provided for:
- Cart button in marketplace
- Order chat button in marketplace order
- Payment dialog in marketplace checkout

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
