### PR TITLE
Various UI fixes and improvements

### DIFF
--- a/src/components/receipt/ReceiptTemplate.vue
+++ b/src/components/receipt/ReceiptTemplate.vue
@@ -85,6 +85,7 @@ export default {
     txFeeFormatted: { type: String, default: null },
     hasFee: Boolean,
     txFeeInFiat: { type: [Number, String], default: null },
+    txFeeInFiatFormatted: { type: String, default: '' },
     merchantData: { type: Object, default: null },
     merchantLogoSrc: { type: String, default: '' },
     hasMemo: Boolean,
@@ -164,8 +165,8 @@ export default {
     },
     txFeeString () {
       if (!this.txFeeFormatted) return ''
-      if (this.txFeeInFiat !== null && this.txFeeInFiat !== undefined && !Number.isNaN(Number(this.txFeeInFiat))) {
-        return `${this.txFeeFormatted} (${this.txFeeInFiat})`
+      if (this.txFeeInFiatFormatted) {
+        return `${this.txFeeFormatted} (${this.txFeeInFiatFormatted})`
       }
       return this.txFeeFormatted
     },

--- a/src/components/receipt/ReceiptTemplate.vue
+++ b/src/components/receipt/ReceiptTemplate.vue
@@ -221,6 +221,9 @@ export default {
   margin-bottom: 30px;
   text-align: center;
 }
+.receipt-amount-box {
+  text-align: center;
+}
 .receipt-type-label {
   font-size: 18px;
   font-weight: 700;
@@ -247,6 +250,7 @@ export default {
 }
 .receipt-detail-row {
   margin-bottom: 20px;
+  text-align: center;
 }
 .receipt-detail-label {
   font-size: 12px;
@@ -255,12 +259,14 @@ export default {
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 6px;
+  text-align: center;
 }
 .receipt-detail-value {
   font-size: 18px;
   font-weight: 600;
   color: #2d3748;
   letter-spacing: 0.2px;
+  text-align: center;
 }
 .receipt-txid {
   font-family: monospace;

--- a/src/components/transactions/TransactionListItem.vue
+++ b/src/components/transactions/TransactionListItem.vue
@@ -111,13 +111,14 @@ const theme = computed(() => $store.getters['global/theme'])
 const useRelativeTxTimestamp = computed(() => Boolean($store.getters['global/relativeTxTimestamp']))
 
 const badgeColor = computed(() => {
+  const level = darkMode.value ? '1' : '3'
   const themeMap = {
-    'glassmorphic-blue': 'blue-3',
-    'glassmorphic-green': 'green-3',
-    'glassmorphic-gold': 'amber-3',
-    'glassmorphic-red': 'pink-3'
+    'glassmorphic-blue': `blue-${level}`,
+    'glassmorphic-green': `green-${level}`,
+    'glassmorphic-gold': `amber-${level}`,
+    'glassmorphic-red': `pink-${level}`
   }
-  return themeMap[theme.value] || 'grey-4'
+  return themeMap[theme.value] || (darkMode.value ? 'grey-8' : 'grey-4')
 })
 
 const decryptedMemo = ref('')

--- a/src/components/transactions/TransactionListItem.vue
+++ b/src/components/transactions/TransactionListItem.vue
@@ -112,12 +112,12 @@ const useRelativeTxTimestamp = computed(() => Boolean($store.getters['global/rel
 
 const badgeColor = computed(() => {
   const themeMap = {
-    'glassmorphic-blue': 'blue-2',
-    'glassmorphic-green': 'green-2',
-    'glassmorphic-gold': 'amber-2',
-    'glassmorphic-red': 'pink-2'
+    'glassmorphic-blue': 'blue-3',
+    'glassmorphic-green': 'green-3',
+    'glassmorphic-gold': 'amber-3',
+    'glassmorphic-red': 'pink-3'
   }
-  return themeMap[theme.value] || 'grey-3'
+  return themeMap[theme.value] || 'grey-4'
 })
 
 const decryptedMemo = ref('')

--- a/src/components/transactions/TransactionListItem.vue
+++ b/src/components/transactions/TransactionListItem.vue
@@ -112,12 +112,12 @@ const useRelativeTxTimestamp = computed(() => Boolean($store.getters['global/rel
 
 const badgeColor = computed(() => {
   const themeMap = {
-    'glassmorphic-blue': 'blue-6',
-    'glassmorphic-green': 'green-6',
-    'glassmorphic-gold': 'amber-7',
-    'glassmorphic-red': 'pink-6'
+    'glassmorphic-blue': 'blue-1',
+    'glassmorphic-green': 'green-1',
+    'glassmorphic-gold': 'amber-1',
+    'glassmorphic-red': 'pink-1'
   }
-  return themeMap[theme.value] || 'blue-6'
+  return themeMap[theme.value] || 'grey-2'
 })
 
 const decryptedMemo = ref('')
@@ -590,6 +590,7 @@ watch(
   align-items: center;
   gap: 4px;
   cursor: pointer;
+  border: 1px solid rgba(128, 128, 128, 0.15);
   transition: all 0.2s ease;
   
   &:hover {

--- a/src/components/transactions/TransactionListItem.vue
+++ b/src/components/transactions/TransactionListItem.vue
@@ -111,14 +111,14 @@ const theme = computed(() => $store.getters['global/theme'])
 const useRelativeTxTimestamp = computed(() => Boolean($store.getters['global/relativeTxTimestamp']))
 
 const badgeColor = computed(() => {
-  const level = darkMode.value ? '1' : '3'
+  if (darkMode.value) return 'grey-8'
   const themeMap = {
-    'glassmorphic-blue': `blue-${level}`,
-    'glassmorphic-green': `green-${level}`,
-    'glassmorphic-gold': `amber-${level}`,
-    'glassmorphic-red': `pink-${level}`
+    'glassmorphic-blue': 'blue-3',
+    'glassmorphic-green': 'green-3',
+    'glassmorphic-gold': 'amber-3',
+    'glassmorphic-red': 'pink-3'
   }
-  return themeMap[theme.value] || (darkMode.value ? 'grey-8' : 'grey-4')
+  return themeMap[theme.value] || 'grey-4'
 })
 
 const decryptedMemo = ref('')

--- a/src/components/transactions/TransactionListItem.vue
+++ b/src/components/transactions/TransactionListItem.vue
@@ -112,12 +112,12 @@ const useRelativeTxTimestamp = computed(() => Boolean($store.getters['global/rel
 
 const badgeColor = computed(() => {
   const themeMap = {
-    'glassmorphic-blue': 'blue-1',
-    'glassmorphic-green': 'green-1',
-    'glassmorphic-gold': 'amber-1',
-    'glassmorphic-red': 'pink-1'
+    'glassmorphic-blue': 'blue-2',
+    'glassmorphic-green': 'green-2',
+    'glassmorphic-gold': 'amber-2',
+    'glassmorphic-red': 'pink-2'
   }
-  return themeMap[theme.value] || 'grey-2'
+  return themeMap[theme.value] || 'grey-3'
 })
 
 const decryptedMemo = ref('')

--- a/src/pages/transaction/transactions.vue
+++ b/src/pages/transaction/transactions.vue
@@ -163,22 +163,24 @@
 							unelevated
 							class="token-action-btn"
 							color="primary"
+							text-color="primary"
 							no-caps
 							outline
 						>
-							<q-icon name="send" size="20px" />
-							{{ $t('Send') }}
+							<q-icon name="send" size="18px" />
+							<span class="action-label">{{ $t('Send') }}</span>
 						</q-btn>
 						<q-btn
 							@click="goToReceive"
 							unelevated
 							class="token-action-btn"
 							color="primary"
+							text-color="primary"
 							no-caps
 							outline
 						>
-							<q-icon name="qr_code_2" size="20px" />
-							{{ $t('Receive') }}
+							<q-icon name="qr_code_2" size="18px" />
+							<span class="action-label">{{ $t('Receive') }}</span>
 						</q-btn>
 						<q-btn
 							v-if="selectedAsset.id?.startsWith?.('ct/')"
@@ -186,11 +188,12 @@
 							unelevated
 							class="token-action-btn"
 							color="primary"
+							text-color="primary"
 							no-caps
 							outline
 						>
-							<q-icon name="swap_horiz" size="20px" />
-							{{ $t('Swap') }}
+							<q-icon name="swap_horiz" size="18px" />
+							<span class="action-label">{{ $t('Swap') }}</span>
 						</q-btn>
 					</div>
 				</div>
@@ -1311,13 +1314,33 @@ this.$nextTick(() => {
 
 .token-actions .token-action-btn {
   flex: 1;
+  min-width: 0;
   border-radius: 10px !important;
   font-weight: 600;
   font-size: 14px;
-  min-height: 48px;
+  min-height: 44px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 2px;
+  padding: 6px 12px;
+}
+
+.token-actions .token-action-btn .action-label {
+  font-weight: 600;
+  line-height: 1.2;
+  font-size: clamp(13px, 2.5vw, 16px);
+}
+
+@media (max-width: 480px) {
+  .token-actions {
+    gap: 6px;
+  }
+  .token-actions .token-action-btn {
+    min-height: 40px;
+    padding: 4px 10px;
+    gap: 2px;
+  }
 }
 </style>

--- a/src/pages/transaction/transactions.vue
+++ b/src/pages/transaction/transactions.vue
@@ -195,9 +195,24 @@
 							<q-icon name="swap_horiz" size="18px" />
 							<span class="action-label">{{ $t('Swap') }}</span>
 						</q-btn>
+						<q-btn
+							v-else-if="selectedAsset.id === 'bch'"
+							@click="showAssetInfoChart"
+							unelevated
+							class="token-action-btn"
+							color="primary"
+							text-color="primary"
+							no-caps
+							outline
+						>
+							<q-icon name="show_chart" size="18px" />
+							<span class="action-label">{{ $t('Chart') }}</span>
+						</q-btn>
 					</div>
 				</div>
 			</div>
+
+			<asset-info ref="asset-info" :network="selectedNetwork"></asset-info>
 
 			<transaction
 			  ref="transaction"
@@ -291,6 +306,7 @@ import Transaction from '../../components/transaction'
 import TransactionList from 'src/components/transactions/TransactionList'
 import TransactionTimestampSettings from 'src/components/transactions/TransactionTimestampSettings.vue'
 import AssetListDialog from '../../pages/transaction/dialog/AssetListDialog.vue'
+import AssetInfo from '../../pages/transaction/dialog/AssetInfo.vue'
 import StablehedgeHistory from 'src/components/stablehedge/StablehedgeHistory.vue'
 import headerNav from 'src/components/header-nav'
 
@@ -474,6 +490,7 @@ export default {
 		StablehedgeHistory,
 		TransactionTimestampSettings,
 		AssetListDialog,
+		AssetInfo,
 		// assetList
 	},
 	async mounted () {				
@@ -1033,6 +1050,11 @@ this.$nextTick(() => {
 	          backPath: this.$route.fullPath
 	        }
 	      })
+	    },
+	    showAssetInfoChart () {
+	      if (this.$refs['asset-info']) {
+	        this.$refs['asset-info'].show(this.selectedAsset)
+	      }
 	    },
 	    hideAssetInfo () {
 	      try {

--- a/src/pages/transaction/transactions.vue
+++ b/src/pages/transaction/transactions.vue
@@ -108,7 +108,7 @@
 		              </template> -->
 		            </div>
 
-			<!-- Token Info Card (shown when a specific token is selected, not "All" or BCH) -->
+			<!-- Token Info Card (shown when a specific asset is selected, not "All") -->
 			<div v-if="showTokenInfoCard" class="token-info-card q-mx-lg q-mt-sm" :class="[getDarkModeClass(darkmode), darkmode ? 'text-light' : 'text-dark']">
 				<div class="token-info-inner">
 					<div class="token-header">
@@ -143,7 +143,7 @@
 							</span>
 							<span v-else class="detail-value text-grey-5">{{ $t('N/A') }}</span>
 						</div>
-						<div class="token-link-row">
+						<div v-if="assetLink" class="token-link-row">
 							<span class="detail-label">{{ $t('Metadata') }}</span>
 							<a
 								:href="assetLink"
@@ -401,8 +401,7 @@ export default {
 	    showTokenInfoCard () {
 	      if (!this.selectedAsset || !this.selectedAsset.id) return false
 	      if (this.selectedAsset.id === 'all') return false
-	      if (this.selectedAsset.id === 'bch') return false
-	      return this.selectedAsset.id.startsWith('ct/') || this.selectedAsset.id.startsWith('slp/')
+	      return true
 	    },
 	    selectedAssetLogoUrl () {
 	      if (!this.selectedAsset) return null
@@ -417,7 +416,7 @@ export default {
 	      return this.$store.getters['market/assetPrices']
 	    },
 	    tokenPrice () {
-	      if (!this.selectedAsset?.id || this.selectedAsset.id === 'bch') return null
+	      if (!this.selectedAsset?.id) return null
 	      const _ = this.assetMarketPrices
 	      const currency = this.$store.getters['market/selectedCurrency']
 	      const symbol = currency?.symbol

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -2280,10 +2280,8 @@ export default {
 
         wrapper = templateEl.cloneNode(true)
         wrapper.style.position = 'fixed'
-        wrapper.style.top = '0'
-        wrapper.style.left = '0'
-        wrapper.style.zIndex = '-9999'
-        wrapper.style.opacity = '0'
+        wrapper.style.top = '-9999px'
+        wrapper.style.left = '-9999px'
         wrapper.style.display = 'block'
         wrapper.style.visibility = 'visible'
         document.body.appendChild(wrapper)
@@ -2296,7 +2294,7 @@ export default {
         }
 
         const canvas = await html2canvas(wrapper, {
-          backgroundColor: null,
+          backgroundColor: '#ffffff',
           scale: 4,
           logging: false,
           useCORS: true,

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -288,7 +288,7 @@
                   rounded
                   @click.stop
                 >
-                  <img v-if="badge?.icon && badge?.icon.startsWith('img:')" :src="badge.icon" class="badge-icon-img q-mr-xs"/>
+                  <img v-if="badge?.icon && badge?.icon.startsWith('img:')" :src="badge.icon.replace('img:', '')" class="badge-icon-img q-mr-xs"/>
                   <q-icon v-else-if="badge?.icon" :name="badge?.icon" class="q-mr-xs" size="14px"/>
                   <span class="badge-text">
                     {{ badge?.text }}

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -847,14 +847,14 @@ export default {
       return this.$store.getters['global/theme']
     },
     badgeColor () {
-      const level = this.darkMode ? '1' : '3'
+      if (this.darkMode) return 'grey-8'
       const themeMap = {
-        'glassmorphic-blue': `blue-${level}`,
-        'glassmorphic-green': `green-${level}`,
-        'glassmorphic-gold': `amber-${level}`,
-        'glassmorphic-red': `pink-${level}`
+        'glassmorphic-blue': 'blue-3',
+        'glassmorphic-green': 'green-3',
+        'glassmorphic-gold': 'amber-3',
+        'glassmorphic-red': 'pink-3'
       }
-      return themeMap[this.theme] || (this.darkMode ? 'grey-8' : 'grey-4')
+      return themeMap[this.theme] || 'grey-4'
     },
     wrapperBackgroundStyle () {
       const theme = this.theme

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -848,12 +848,12 @@ export default {
     },
     badgeColor () {
       const themeMap = {
-        'glassmorphic-blue': 'blue-6',
-        'glassmorphic-green': 'green-6',
-        'glassmorphic-gold': 'amber-7',
-        'glassmorphic-red': 'pink-6'
+        'glassmorphic-blue': 'blue-1',
+        'glassmorphic-green': 'green-1',
+        'glassmorphic-gold': 'amber-1',
+        'glassmorphic-red': 'pink-1'
       }
-      return themeMap[this.theme] || 'blue-6'
+      return themeMap[this.theme] || 'grey-2'
     },
     wrapperBackgroundStyle () {
       const theme = this.theme
@@ -2995,6 +2995,7 @@ export default {
   align-items: center;
   gap: 4px;
   cursor: pointer;
+  border: 1px solid rgba(128, 128, 128, 0.15);
   transition: all 0.2s ease;
 }
 

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -848,12 +848,12 @@ export default {
     },
     badgeColor () {
       const themeMap = {
-        'glassmorphic-blue': 'blue-2',
-        'glassmorphic-green': 'green-2',
-        'glassmorphic-gold': 'amber-2',
-        'glassmorphic-red': 'pink-2'
+        'glassmorphic-blue': 'blue-3',
+        'glassmorphic-green': 'green-3',
+        'glassmorphic-gold': 'amber-3',
+        'glassmorphic-red': 'pink-3'
       }
-      return themeMap[this.theme] || 'grey-3'
+      return themeMap[this.theme] || 'grey-4'
     },
     wrapperBackgroundStyle () {
       const theme = this.theme

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -462,6 +462,7 @@
     :tx-fee-formatted="txFeeFormatted"
     :has-fee="hasFeeForReceipt"
     :tx-fee-in-fiat="txFeeInFiat"
+    :tx-fee-in-fiat-formatted="txFeeInFiatFormatted"
     :merchant-data="merchantData"
     :merchant-logo-src="merchantLogoSrcForReceipt"
     :has-memo="hasMemo"
@@ -707,6 +708,10 @@ export default {
 
       const fiatValue = this.txFee * price;
       return fiatValue;
+    },
+    txFeeInFiatFormatted() {
+      if (this.txFeeInFiat === null || this.txFeeInFiat === undefined) return ''
+      return this.formatTxFeeInFiat(this.txFeeInFiat)
     },
     txFeeFormatted() {
       if (this.txFee === null || Number.isNaN(this.txFee)) return '';

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -505,7 +505,10 @@ export default {
   props: {
     txid: String,
     category: String,
-    from: String
+    from: String,
+    assetID: String,
+    new: String,
+    recipient: String
   },
   data () {
     return {

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -2310,18 +2310,32 @@ export default {
           document.body.removeChild(wrapper)
         }
 
+        const canvasToBlob = async (cvs, mimeType, q) => {
+          try {
+            return await new Promise(resolve => {
+              cvs.toBlob(resolve, mimeType, q)
+            })
+          } catch {
+            return null
+          }
+        }
+
         const compressImage = async (canvas) => {
-          let quality = 0.95
-          let blob = await new Promise(resolve => {
-            canvas.toBlob(resolve, 'image/jpeg', quality)
-          })
-          for (const q of [0.92, 0.90, 0.88]) {
-            if (blob && blob.size > 300000) {
-              quality = q
-              blob = await new Promise(resolve => {
-                canvas.toBlob(resolve, 'image/jpeg', quality)
-              })
+          let blob = await canvasToBlob(canvas, 'image/png')
+          if (!blob) {
+            try {
+              const dataUrl = canvas.toDataURL('image/png')
+              const byteString = atob(dataUrl.split(',')[1])
+              const ab = new ArrayBuffer(byteString.length)
+              const ia = new Uint8Array(ab)
+              for (let i = 0; i < byteString.length; i++) ia[i] = byteString.charCodeAt(i)
+              blob = new Blob([ab], { type: 'image/png' })
+            } catch {
+              return null
             }
+          }
+          if (blob.size > 300000) {
+            blob = await canvasToBlob(canvas, 'image/jpeg', 0.92)
           }
           if (blob && blob.size > 300000) {
             const maxDimension = 1600
@@ -2335,9 +2349,7 @@ export default {
             resizedCtx.imageSmoothingEnabled = true
             resizedCtx.imageSmoothingQuality = 'high'
             resizedCtx.drawImage(canvas, 0, 0, newWidth, newHeight)
-            blob = await new Promise(resolve => {
-              resizedCanvas.toBlob(resolve, 'image/jpeg', 0.90)
-            })
+            blob = await canvasToBlob(resizedCanvas, 'image/jpeg', 0.90) || blob
           }
           if (blob && blob.size > 300000) {
             const maxDimension = 1400
@@ -2351,15 +2363,13 @@ export default {
             resizedCtx.imageSmoothingEnabled = true
             resizedCtx.imageSmoothingQuality = 'high'
             resizedCtx.drawImage(canvas, 0, 0, newWidth, newHeight)
-            blob = await new Promise(resolve => {
-              resizedCanvas.toBlob(resolve, 'image/jpeg', 0.88)
-            })
+            blob = await canvasToBlob(resizedCanvas, 'image/jpeg', 0.88) || blob
           }
           return blob
         }
 
         const blob = await compressImage(canvas)
-        if (!blob) throw new Error('Failed to create receipt image blob')
+        if (!blob) throw new Error('Failed to create receipt image blob: canvas export returned null')
 
         const shortTxId = this.transactionId.substring(0, 8)
         const filename = `receipt-${shortTxId}.jpg`

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -847,13 +847,14 @@ export default {
       return this.$store.getters['global/theme']
     },
     badgeColor () {
+      const level = this.darkMode ? '1' : '3'
       const themeMap = {
-        'glassmorphic-blue': 'blue-3',
-        'glassmorphic-green': 'green-3',
-        'glassmorphic-gold': 'amber-3',
-        'glassmorphic-red': 'pink-3'
+        'glassmorphic-blue': `blue-${level}`,
+        'glassmorphic-green': `green-${level}`,
+        'glassmorphic-gold': `amber-${level}`,
+        'glassmorphic-red': `pink-${level}`
       }
-      return themeMap[this.theme] || 'grey-4'
+      return themeMap[this.theme] || (this.darkMode ? 'grey-8' : 'grey-4')
     },
     wrapperBackgroundStyle () {
       const theme = this.theme

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -848,12 +848,12 @@ export default {
     },
     badgeColor () {
       const themeMap = {
-        'glassmorphic-blue': 'blue-1',
-        'glassmorphic-green': 'green-1',
-        'glassmorphic-gold': 'amber-1',
-        'glassmorphic-red': 'pink-1'
+        'glassmorphic-blue': 'blue-2',
+        'glassmorphic-green': 'green-2',
+        'glassmorphic-gold': 'amber-2',
+        'glassmorphic-red': 'pink-2'
       }
-      return themeMap[this.theme] || 'grey-2'
+      return themeMap[this.theme] || 'grey-3'
     },
     wrapperBackgroundStyle () {
       const theme = this.theme

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -502,7 +502,9 @@ export default {
   name: 'TransactionDetailPage',
   components: { headerNav, ReceiptTemplate },
   props: {
-    txid: String
+    txid: String,
+    category: String,
+    from: String
   },
   data () {
     return {

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -1133,8 +1133,11 @@ export default {
     darkMode () {
       this.updateBackgroundColors()
     },
-    recipientAddress (addr) {
-      if (addr) this.fetchMerchantData()
+    recipientAddress: {
+      handler (addr) {
+        if (addr) this.fetchMerchantData()
+      },
+      immediate: true
     },
     'tx.asset.id' () {
       // Fetch token price when asset changes

--- a/src/pages/transactions/TransactionDetail.vue
+++ b/src/pages/transactions/TransactionDetail.vue
@@ -2284,10 +2284,16 @@ export default {
         wrapper.style.left = '0'
         wrapper.style.zIndex = '-9999'
         wrapper.style.opacity = '0'
+        wrapper.style.display = 'block'
+        wrapper.style.visibility = 'visible'
         document.body.appendChild(wrapper)
 
         await this.$nextTick()
         await new Promise(resolve => setTimeout(resolve, 200))
+
+        if (!wrapper.offsetWidth || !wrapper.offsetHeight) {
+          throw new Error('Receipt element has zero dimensions')
+        }
 
         const canvas = await html2canvas(wrapper, {
           backgroundColor: null,


### PR DESCRIPTION
## Summary

Collection of UI fixes addressing visual issues across transaction list, transaction detail, and receipt features.

## Changes

### Transaction List Page
- **Token info card for BCH**: The info card (with Send/Receive/Chart buttons) now shows for BCH assets, not just cash tokens.
- **Chart button for BCH**: Opens the AssetInfo price chart dialog.
- **Action button centering**: Fixed text alignment in Send/Receive/Swap buttons on mobile by switching to column layout.

### Transaction Detail Page
- **Merchant info display**: Fixed merchant data not loading on initial page load by making the watcher fire immediately.
- **Receipt save**: Fixed blank/black JPEG output by using off-screen positioning instead of `opacity: 0` (which made the canvas transparent). Added PNG fallback for `toBlob` failures.
- **Receipt centering**: All receipt content is now center-aligned in the saved image.
- **Fee fiat formatting**: Network fee fiat value now uses locale-aware formatting with proper decimals and currency symbol.
- **Vue prop warnings**: Declared missing props (`category`, `from`, `assetID`, `new`, `recipient`) to silence extraneous attributes warnings.

### Transaction Badges (both views)
- Toned down attribute badge colors to be less conspicuous — light mode uses level 3 pastels, dark mode uses neutral gray.