### PR TITLE
Move room storage to server; server-authoritative room list

### DIFF
--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -330,6 +330,7 @@ export default {
         })
         
         this.$store.commit('nostrChat/ADD_MESSAGE', { roomId: this.roomId, message })
+        this.$store.dispatch('nostrChat/touchRoom', { roomId: this.roomId, timestamp: new Date().toISOString() })
         await this.$store.dispatch('nostrChat/publishGiftWraps', { giftWraps })
         const myPubKey = this.$store.getters['nostrChat/myPubKey']
         const room = this.$store.getters['nostrChat/getRoom'](this.roomId)

--- a/src/components/chat/RoomList.vue
+++ b/src/components/chat/RoomList.vue
@@ -54,8 +54,8 @@
                 {{ $t('Group', {}, 'Group') }}
               </q-badge>
             </div>
-            <div v-if="room.updatedAt" class="room-time">
-              {{ formatTime(room.updatedAt) }}
+            <div v-if="room.lastMessageAt || lastMessageTime(room.id) || room.updatedAt" class="room-time">
+              {{ formatTime(room.lastMessageAt || lastMessageTime(room.id) || room.updatedAt) }}
             </div>
           </div>
           <div class="room-preview-row">
@@ -299,6 +299,12 @@ export default {
       }
       const { text } = parseMessageMarkup(last.content)
       return text
+    },
+    lastMessageTime (roomId) {
+      const msgs = this.messages[roomId] || []
+      if (!msgs.length) return null
+      const last = msgs[msgs.length - 1]
+      return last.created_at || null
     },
     formatTime (ts) {
       try {

--- a/src/pages/apps/chat/conversation.vue
+++ b/src/pages/apps/chat/conversation.vue
@@ -1683,7 +1683,7 @@ export default {
       try {
         const name = this.renameGroupName.trim()
         if (!name || !this.room) return
-        this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name })
+        await this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name })
         const text = this.$t('GroupRenamedTo', { name }, `Changed group name to "${name}"`)
         const { giftWraps, message, roomId } = await this.$store.dispatch('nostrChat/sendMessage', {
           roomId: this.roomId,

--- a/src/pages/apps/chat/conversation.vue
+++ b/src/pages/apps/chat/conversation.vue
@@ -1252,11 +1252,11 @@ export default {
       // Always ensure we have an active subscription,
       // especially after the tab has been backgrounded.
       if (!this.$store.getters['nostrChat/isInitialized']) {
-        this.$store.dispatch('nostrChat/initialize').then(() => {
-          this.$store.dispatch('nostrChat/subscribeToRelays')
+        return this.$store.dispatch('nostrChat/initialize').then(() => {
+          return this.$store.dispatch('nostrChat/subscribeToRelays')
         })
       } else {
-        this.$store.dispatch('nostrChat/subscribeToRelays')
+        return this.$store.dispatch('nostrChat/subscribeToRelays')
       }
     },
     async requestToJoin () {

--- a/src/pages/apps/chat/conversation.vue
+++ b/src/pages/apps/chat/conversation.vue
@@ -227,6 +227,7 @@
             outlined
             dense
             rounded
+            maxlength="100"
             class="q-mb-md"
             autofocus
             @keyup.enter="renameGroup"
@@ -1030,10 +1031,10 @@ export default {
         this.observeMessages()
       })
     })
-    // Poll active status every 2 minutes while on this page
+    // Poll active status every minute while on this page
     this._activeStatusPollTimer = setInterval(() => {
       this.$store.dispatch('nostrChat/fetchActiveStatus').catch(() => {})
-    }, 120000)
+    }, 60000)
     this._isActive = true
   },
   activated () {
@@ -1044,7 +1045,7 @@ export default {
     if (!this._activeStatusPollTimer) {
       this._activeStatusPollTimer = setInterval(() => {
         this.$store.dispatch('nostrChat/fetchActiveStatus').catch(() => {})
-      }, 120000)
+      }, 60000)
     }
     if (this.isGroupRoom && this.room?.members) {
       const fetches = this.room.members.map(pk =>
@@ -1611,6 +1612,7 @@ export default {
             replyTo,
           })
           this.$store.commit('nostrChat/ADD_MESSAGE', { roomId, message })
+          this.$store.dispatch('nostrChat/touchRoom', { roomId, timestamp: new Date().toISOString() })
           this.replyToMessage = null
           this.scrollToBottom()
           await this.$store.dispatch('nostrChat/publishGiftWraps', { giftWraps })
@@ -1640,7 +1642,7 @@ export default {
         // Update room name to the new contact name
         const contact = this.$store.getters['nostrChat/getContactByNpub'](npub)
         if (contact && this.room) {
-          this.$store.commit('nostrChat/UPDATE_ROOM_NAME', {
+          this.$store.dispatch('nostrChat/updateRoomName', {
             roomId: this.roomId,
             name: contact.name,
           })
@@ -1681,7 +1683,7 @@ export default {
       try {
         const name = this.renameGroupName.trim()
         if (!name || !this.room) return
-        this.$store.commit('nostrChat/UPDATE_ROOM_NAME', { roomId: this.roomId, name })
+        this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name })
         const text = this.$t('GroupRenamedTo', { name }, `Changed group name to "${name}"`)
         const { giftWraps, message, roomId } = await this.$store.dispatch('nostrChat/sendMessage', {
           roomId: this.roomId,
@@ -1748,7 +1750,7 @@ export default {
 
         // Update room name to match
         if (this.room) {
-          this.$store.commit('nostrChat/UPDATE_ROOM_NAME', {
+          this.$store.dispatch('nostrChat/updateRoomName', {
             roomId: this.roomId,
             name,
           })
@@ -1778,7 +1780,7 @@ export default {
         ok: { label: this.$t('Archive', {}, 'Archive'), color: 'primary', flat: true },
         persistent: true,
       }).onOk(() => {
-        this.$store.commit('nostrChat/ARCHIVE_ROOM', this.roomId)
+        this.$store.dispatch('nostrChat/archiveRoom', this.roomId)
         this.$router.replace('/apps/chat')
         this.$q.notify({
           type: 'info',
@@ -1787,7 +1789,7 @@ export default {
       })
     },
     unarchiveRoom () {
-      this.$store.commit('nostrChat/UNARCHIVE_ROOM', this.roomId)
+      this.$store.dispatch('nostrChat/unarchiveRoom', this.roomId)
       this.$q.notify({
         type: 'positive',
         message: this.$t('ConversationUnarchived', {}, 'Conversation unarchived'),
@@ -1805,8 +1807,8 @@ export default {
         persistent: true,
       }).onOk(() => {
         if (otherPubKey) {
-          this.$store.commit('nostrChat/BLOCK_CONTACT', otherPubKey)
-          this.$store.commit('nostrChat/ARCHIVE_ROOM', this.roomId)
+          this.$store.dispatch('nostrChat/blockContact', otherPubKey)
+          this.$store.dispatch('nostrChat/archiveRoom', this.roomId)
         }
         this.$router.replace('/apps/chat')
         this.$q.notify({
@@ -1827,8 +1829,8 @@ export default {
         persistent: true,
       }).onOk(() => {
         if (otherPubKey) {
-          this.$store.commit('nostrChat/UNBLOCK_CONTACT', otherPubKey)
-          this.$store.commit('nostrChat/UNARCHIVE_ROOM', this.roomId)
+          this.$store.dispatch('nostrChat/unblockContact', otherPubKey)
+          this.$store.dispatch('nostrChat/unarchiveRoom', this.roomId)
         }
         this.$q.notify({
           type: 'positive',
@@ -1853,8 +1855,8 @@ export default {
           ok: { label: this.$t('Delete', {}, 'Delete'), color: 'negative', flat: true },
           persistent: true,
         }).onOk(() => {
-          this.$store.commit('nostrChat/UNBLOCK_GROUP', this.roomId)
-          this.$store.commit('nostrChat/REMOVE_ROOM', this.roomId)
+          this.$store.dispatch('nostrChat/unblockGroup', this.roomId)
+          this.$store.dispatch('nostrChat/deleteRoom', this.roomId)
           this.$router.replace('/apps/chat')
           this.$q.notify({ type: 'info', message: this.$t('ConversationDeleted', {}, 'Conversation deleted') })
         })
@@ -1870,7 +1872,7 @@ export default {
           ok: { label: this.$t('Delete', {}, 'Delete'), color: 'negative', flat: true },
           persistent: true,
         }).onOk(() => {
-          this.$store.commit('nostrChat/REMOVE_ROOM', this.roomId)
+          this.$store.dispatch('nostrChat/deleteRoom', this.roomId)
           this.$router.replace('/apps/chat')
           this.$q.notify({
             type: 'info',
@@ -1903,9 +1905,9 @@ export default {
           persistent: true,
         }).onOk((option) => {
           if (option === 'block_delete' && otherPubKey) {
-            this.$store.commit('nostrChat/BLOCK_CONTACT', otherPubKey)
+            this.$store.dispatch('nostrChat/blockContact', otherPubKey)
           }
-          this.$store.commit('nostrChat/REMOVE_ROOM', this.roomId)
+          this.$store.dispatch('nostrChat/deleteRoom', this.roomId)
           this.$router.replace('/apps/chat')
           this.$q.notify({
             type: 'info',
@@ -2001,6 +2003,7 @@ export default {
             text,
           })
           this.$store.commit('nostrChat/ADD_MESSAGE', { roomId, message })
+          this.$store.dispatch('nostrChat/touchRoom', { roomId, timestamp: new Date().toISOString() })
           await this.$store.dispatch('nostrChat/publishGiftWraps', { giftWraps })
         } catch (err) {
           console.error('[Conversation] Failed to send confirmation message:', err)

--- a/src/pages/apps/chat/dm-info.vue
+++ b/src/pages/apps/chat/dm-info.vue
@@ -263,11 +263,11 @@ export default {
       this.savingSubject = true
       try {
         if (subject) {
-          this.$store.commit('nostrChat/UPDATE_ROOM_NAME', { roomId: this.roomId, name: subject })
+          this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name: subject })
         } else if (this.otherMemberContact) {
-          this.$store.commit('nostrChat/UPDATE_ROOM_NAME', { roomId: this.roomId, name: this.otherMemberContact.name })
+          this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name: this.otherMemberContact.name })
         }
-        this.$store.commit('nostrChat/UPDATE_ROOM_SUBJECT', { roomId: this.roomId, subject: subject || null })
+        this.$store.dispatch('nostrChat/updateRoomSubject', { roomId: this.roomId, subject: subject || null })
         let text
         if (subject) {
           text = this.$t('SubjectChangedTo', { subject }, `Changed subject to "${subject}"`)

--- a/src/pages/apps/chat/dm-info.vue
+++ b/src/pages/apps/chat/dm-info.vue
@@ -263,11 +263,11 @@ export default {
       this.savingSubject = true
       try {
         if (subject) {
-          this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name: subject })
+          await this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name: subject })
         } else if (this.otherMemberContact) {
-          this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name: this.otherMemberContact.name })
+          await this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name: this.otherMemberContact.name })
         }
-        this.$store.dispatch('nostrChat/updateRoomSubject', { roomId: this.roomId, subject: subject || null })
+        await this.$store.dispatch('nostrChat/updateRoomSubject', { roomId: this.roomId, subject: subject || null })
         let text
         if (subject) {
           text = this.$t('SubjectChangedTo', { subject }, `Changed subject to "${subject}"`)

--- a/src/pages/apps/chat/group-info.vue
+++ b/src/pages/apps/chat/group-info.vue
@@ -325,7 +325,7 @@ export default {
       if (!name || !this.room) return
       this.savingName = true
       try {
-        this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name })
+        await this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name })
         const text = this.$t('GroupRenamedTo', { name }, `Changed group name to "${name}"`)
         const { giftWraps, message, roomId } = await this.$store.dispatch('nostrChat/sendMessage', {
           roomId: this.roomId,

--- a/src/pages/apps/chat/group-info.vue
+++ b/src/pages/apps/chat/group-info.vue
@@ -325,7 +325,7 @@ export default {
       if (!name || !this.room) return
       this.savingName = true
       try {
-        this.$store.commit('nostrChat/UPDATE_ROOM_NAME', { roomId: this.roomId, name })
+        this.$store.dispatch('nostrChat/updateRoomName', { roomId: this.roomId, name })
         const text = this.$t('GroupRenamedTo', { name }, `Changed group name to "${name}"`)
         const { giftWraps, message, roomId } = await this.$store.dispatch('nostrChat/sendMessage', {
           roomId: this.roomId,

--- a/src/pages/apps/chat/index.vue
+++ b/src/pages/apps/chat/index.vue
@@ -296,6 +296,7 @@
                   outlined
                   dense
                   rounded
+                  maxlength="100"
                   class="q-mb-sm"
                   autofocus
                 />
@@ -652,10 +653,10 @@ export default {
     }
     document.addEventListener('visibilitychange', this._onVisibilityChange)
 
-    // Poll active status every 2 minutes while on this page
+    // Poll active status every minute while on this page
     this._activeStatusPollTimer = setInterval(() => {
       this.$store.dispatch('nostrChat/fetchActiveStatus').catch(() => {})
-    }, 120000)
+    }, 60000)
   },
   activated () {
     // Re-check subscription when returning to this page via keep-alive
@@ -765,7 +766,7 @@ export default {
         },
         persistent: true,
       }).onOk(() => {
-        this.$store.commit('nostrChat/ARCHIVE_ROOM', roomId)
+        this.$store.dispatch('nostrChat/archiveRoom', roomId)
         this.$q.notify({
           type: 'info',
           message: this.$t('ConversationArchived', {}, 'Conversation archived'),
@@ -796,8 +797,8 @@ export default {
         },
         persistent: true,
       }).onOk(() => {
-        this.$store.commit('nostrChat/BLOCK_CONTACT', otherPubKey)
-        this.$store.commit('nostrChat/ARCHIVE_ROOM', roomId)
+        this.$store.dispatch('nostrChat/blockContact', otherPubKey)
+        this.$store.dispatch('nostrChat/archiveRoom', roomId)
         this.$q.notify({
           type: 'info',
           message: this.$t('ContactBlocked', {}, 'Contact blocked'),
@@ -828,8 +829,8 @@ export default {
         },
         persistent: true,
       }).onOk(() => {
-        this.$store.commit('nostrChat/UNBLOCK_CONTACT', otherPubKey)
-        this.$store.commit('nostrChat/UNARCHIVE_ROOM', roomId)
+        this.$store.dispatch('nostrChat/unblockContact', otherPubKey)
+        this.$store.dispatch('nostrChat/unarchiveRoom', roomId)
         this.$q.notify({
           type: 'positive',
           message: this.$t('ContactUnblocked', {}, 'Contact unblocked'),
@@ -843,7 +844,7 @@ export default {
         this.confirmRejoinGroup(roomId)
         return
       }
-      this.$store.commit('nostrChat/UNARCHIVE_ROOM', roomId)
+      this.$store.dispatch('nostrChat/unarchiveRoom', roomId)
       this.$q.notify({
         type: 'positive',
         message: this.$t('ConversationUnarchived', {}, 'Conversation unarchived'),
@@ -906,8 +907,8 @@ export default {
           ok: { label: this.$t('Delete', {}, 'Delete'), color: 'negative', flat: true },
           persistent: true,
         }).onOk(() => {
-          this.$store.commit('nostrChat/UNBLOCK_GROUP', roomId)
-          this.$store.commit('nostrChat/REMOVE_ROOM', roomId)
+          this.$store.dispatch('nostrChat/unblockGroup', roomId)
+          this.$store.dispatch('nostrChat/deleteRoom', roomId)
           this.$q.notify({ type: 'info', message: this.$t('ConversationDeleted', {}, 'Conversation deleted') })
         })
         return
@@ -934,7 +935,7 @@ export default {
           },
           persistent: true,
         }).onOk(() => {
-          this.$store.commit('nostrChat/REMOVE_ROOM', roomId)
+          this.$store.dispatch('nostrChat/deleteRoom', roomId)
           this.$q.notify({
             type: 'info',
             message: this.$t('ConversationDeleted', {}, 'Conversation deleted'),
@@ -977,9 +978,9 @@ export default {
         persistent: true,
       }).onOk((option) => {
         if (option === 'block_delete' && otherPubKey) {
-          this.$store.commit('nostrChat/BLOCK_CONTACT', otherPubKey)
+          this.$store.dispatch('nostrChat/blockContact', otherPubKey)
         }
-        this.$store.commit('nostrChat/REMOVE_ROOM', roomId)
+        this.$store.dispatch('nostrChat/deleteRoom', roomId)
         this.$q.notify({
           type: 'info',
           message: this.$t('ConversationDeleted', {}, 'Conversation deleted'),

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -194,6 +194,12 @@ function reducer(state) {
                       }
                       continue
                     }
+
+                    // Room lists, deleted rooms, and block lists are stored server-side.
+                    // Only keep an in-memory cache; don't persist to localStorage.
+                    if (moduleName === 'nostrChat' && ['rooms', 'deletedRooms', 'blockedContacts', 'blockedGroups'].includes(key)) {
+                      continue
+                    }
                     
                     // Skip functions
                     if (typeof value === 'function') {

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -1,6 +1,6 @@
 import { ACTIVE_THRESHOLD_MS } from './state'
 import { deriveNostrKeys, createUnsignedKind14, createNip17GiftWraps, computeRoomId, createKind10050, createReadReceiptGiftWrap, createReactionGiftWraps, createKind5DeletionGiftWraps } from 'src/wallet/nostr'
-import { finalizeEvent, verifyEvent, getEventHash, utils as nostrUtils } from 'nostr-tools'
+import { finalizeEvent, verifyEvent, getEventHash, nip44, utils as nostrUtils } from 'nostr-tools'
 const { hexToBytes } = nostrUtils
 
 // Tracks retry attempts for failed read receipt sends. Keyed by roomId:messageId,
@@ -14,6 +14,54 @@ const _markRoomLocks = new Set()
 // Keyed by messageId → [{ readerPubKey }]. Flushed at the end of every
 // receiveMessage call.
 const _pendingReadReceipts = new Map()
+
+// Per-room debounce timers for touchRoom. During the initial relay sync,
+// messages stream in rapidly — touching the server for every one would be
+// excessive. Instead we debounce: each new message resets a 2s timer for
+// its room, and only the last message in each burst triggers the touch.
+const _roomTouchTimers = {}
+const _roomTouchPending = {}
+
+// Debounced re-fetch of room list. When the relay discovers rooms not in
+// the local cache, we batch them into a single reload after a short quiet
+// period so rapid bursts don't hammer the server. Each new call resets
+// the timer so the fetch always fires after the last discovery.
+let _refetchRoomsTimer = null
+
+function debouncedRefetchRooms (dispatch) {
+  if (_refetchRoomsTimer) clearTimeout(_refetchRoomsTimer)
+  _refetchRoomsTimer = setTimeout(() => {
+    _refetchRoomsTimer = null
+    dispatch('fetchRooms').catch(() => {})
+  }, 2000)
+}
+
+function queueRoomTouch (dispatch, roomId, timestamp) {
+  _roomTouchPending[roomId] = timestamp
+  if (_roomTouchTimers[roomId]) clearTimeout(_roomTouchTimers[roomId])
+  _roomTouchTimers[roomId] = setTimeout(() => {
+    const ts = _roomTouchPending[roomId]
+    delete _roomTouchPending[roomId]
+    delete _roomTouchTimers[roomId]
+    dispatch('touchRoom', { roomId, timestamp: ts })
+  }, 2000)
+}
+
+function flushRoomTouch (dispatch, roomId) {
+  if (_roomTouchTimers[roomId]) clearTimeout(_roomTouchTimers[roomId])
+  delete _roomTouchTimers[roomId]
+  const ts = _roomTouchPending[roomId]
+  if (ts) {
+    delete _roomTouchPending[roomId]
+    dispatch('touchRoom', { roomId, timestamp: ts })
+  }
+}
+
+function flushAllRoomTouches (dispatch) {
+  for (const roomId of Object.keys(_roomTouchPending)) {
+    flushRoomTouch(dispatch, roomId)
+  }
+}
 
 function flushPendingReadReceipts (state, commit) {
   if (!_pendingReadReceipts.size) return
@@ -31,7 +79,7 @@ function flushPendingReadReceipts (state, commit) {
     }
   }
 }
-import { getMnemonic } from 'src/wallet'
+import { getMnemonic, getMnemonicByHash } from 'src/wallet'
 import { decode as nip19Decode } from 'nostr-tools/nip19'
 import * as relayService from 'src/services/nostr-chat'
 import Watchtower from 'watchtower-cash-js'
@@ -93,9 +141,10 @@ const DISCOVERY_RELAYS = [
   'wss://relay.paytaca.com',
 ]
 
-export async function reinitialize ({ commit, dispatch, state, rootGetters }) {
-  const walletIndex = rootGetters['global/getWalletIndex']
-  const mnemonic = await getMnemonic(walletIndex)
+export async function reinitialize ({ commit, dispatch, state }) {
+  const walletHash = getCurrentWalletHash()
+  if (!walletHash) return
+  const mnemonic = await getMnemonicByHash(walletHash)
   if (!mnemonic) return
 
   const keys = deriveNostrKeys(mnemonic)
@@ -141,9 +190,10 @@ export async function reinitialize ({ commit, dispatch, state, rootGetters }) {
   dispatch('subscribeToRelays')
 }
 
-export async function initialize ({ commit, dispatch, state, rootGetters }) {
-  const walletIndex = rootGetters['global/getWalletIndex']
-  const mnemonic = await getMnemonic(walletIndex)
+export async function initialize ({ commit, dispatch, state }) {
+  const walletHash = getCurrentWalletHash()
+  if (!walletHash) throw new Error('No wallet hash available')
+  const mnemonic = await getMnemonicByHash(walletHash)
   if (!mnemonic) throw new Error('No mnemonic available')
 
   const keys = deriveNostrKeys(mnemonic)
@@ -1084,7 +1134,400 @@ export async function setShowActiveStatus ({ commit, dispatch, getters, rootGett
   }
 }
 
-export function createPrivateRoom ({ commit, getters, state }, contactNpub) {
+// ── Server API helpers ──────────────────────────────────────────────
+
+function getWatchtowerBaseUrl () {
+  try {
+    const isChipnet = Store.getters['global/isChipnet']
+    return isChipnet ? 'https://chipnet.watchtower.cash' : 'https://watchtower.cash'
+  } catch {
+    return 'https://watchtower.cash'
+  }
+}
+
+async function apiPost (baseUrl, path, body) {
+  const authHeaders = await getAuthHeaders()
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders },
+    body: JSON.stringify(body),
+  })
+  if (response.status === 401) {
+    await clearToken()
+    const retryHeaders = await getAuthHeaders()
+    return fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...retryHeaders },
+      body: JSON.stringify(body),
+    })
+  }
+  return response
+}
+
+async function apiPatch (baseUrl, path, body) {
+  const authHeaders = await getAuthHeaders()
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...authHeaders },
+    body: JSON.stringify(body),
+  })
+  if (response.status === 401) {
+    await clearToken()
+    const retryHeaders = await getAuthHeaders()
+    return fetch(`${baseUrl}${path}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...retryHeaders },
+      body: JSON.stringify(body),
+    })
+  }
+  return response
+}
+
+async function apiGet (baseUrl, path) {
+  const authHeaders = await getAuthHeaders()
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', ...authHeaders },
+  })
+  if (response.status === 401) {
+    await clearToken()
+    const retryHeaders = await getAuthHeaders()
+    return fetch(`${baseUrl}${path}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json', ...retryHeaders },
+    })
+  }
+  return response
+}
+
+async function apiDelete (baseUrl, path, body) {
+  const authHeaders = await getAuthHeaders()
+  const fetchOpts = {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', ...authHeaders },
+  }
+  if (body) fetchOpts.body = JSON.stringify(body)
+  const response = await fetch(`${baseUrl}${path}`, fetchOpts)
+  if (response.status === 401) {
+    await clearToken()
+    const retryHeaders = await getAuthHeaders()
+    const retryOpts = {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', ...retryHeaders },
+    }
+    if (body) retryOpts.body = JSON.stringify(body)
+    return fetch(`${baseUrl}${path}`, retryOpts)
+  }
+  return response
+}
+
+// ── Room name encryption helpers ────────────────────────────────────
+// Group names are encrypted client-side before storing on the server
+// so that room metadata remains private. The encryption key is derived
+// fresh from the mnemonic seed phrase (never read from persisted state).
+
+let _roomNameEncryptionKey = null
+let _roomNameEncryptionKeyPromise = null
+
+async function getRoomNameEncryptionKey () {
+  if (_roomNameEncryptionKey) return _roomNameEncryptionKey
+  if (_roomNameEncryptionKeyPromise) return _roomNameEncryptionKeyPromise
+  _roomNameEncryptionKeyPromise = (async () => {
+    try {
+      const walletHash = getCurrentWalletHash()
+      if (!walletHash) return null
+      const mnemonic = await getMnemonicByHash(walletHash)
+      if (!mnemonic) return null
+      const keys = deriveNostrKeys(mnemonic)
+      const key = nip44.getConversationKey(hexToBytes(keys.privKeyHex), keys.pubKeyHex)
+      _roomNameEncryptionKey = key
+      return key
+    } catch {
+      return null
+    } finally {
+      _roomNameEncryptionKeyPromise = null
+    }
+  })()
+  return _roomNameEncryptionKeyPromise
+}
+
+const MAX_ROOM_NAME_LENGTH = 100
+
+async function encryptRoomName (name) {
+  if (!name) return name
+  try {
+    const key = await getRoomNameEncryptionKey()
+    if (!key) return name
+    const truncated = name.length > MAX_ROOM_NAME_LENGTH
+      ? name.slice(0, MAX_ROOM_NAME_LENGTH)
+      : name
+    return nip44.encrypt(truncated, key)
+  } catch {
+    return name
+  }
+}
+
+async function decryptRoomName (encrypted) {
+  if (!encrypted) return encrypted
+  try {
+    const key = await getRoomNameEncryptionKey()
+    if (!key) return encrypted
+    return nip44.decrypt(encrypted, key)
+  } catch {
+    return encrypted
+  }
+}
+
+async function decryptRoomsList (rooms) {
+  if (!rooms) return rooms
+  const decrypted = []
+  for (const r of rooms) {
+    const createdAt = r.created_at || r.createdAt
+    const updatedAt = r.updated_at || r.updatedAt
+    const lastMsgTs = r.last_message_timestamp
+    decrypted.push({
+      id: r.room_id || r.id,
+      type: r.type,
+      name: await decryptRoomName(r.name),
+      members: r.members || [],
+      subject: r.subject,
+      archived: !!r.archived,
+      createdAt: typeof createdAt === 'string' ? Math.floor(new Date(createdAt).getTime() / 1000) : createdAt,
+      updatedAt: typeof updatedAt === 'string' ? Math.floor(new Date(updatedAt).getTime() / 1000) : updatedAt,
+      lastMessageAt: typeof lastMsgTs === 'string' ? Math.floor(new Date(lastMsgTs).getTime() / 1000) : lastMsgTs,
+    })
+  }
+  return decrypted
+}
+
+// ── Server-backed room actions ──────────────────────────────────────
+
+export async function fetchRooms ({ commit, dispatch, state }) {
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiGet(baseUrl, `/api/nostr/rooms/?wallet_hash=${walletHash}`)
+    if (!response.ok) {
+      debug('fetchRooms failed:', response.status)
+      return
+    }
+    const data = await response.json()
+    if (Array.isArray(data.rooms)) {
+      const decrypted = await decryptRoomsList(data.rooms)
+      commit('SET_ROOMS', decrypted)
+
+      const ws = getWalletState(state)
+
+      // For groups with placeholder names, try to find the real name from
+      // message subject tags, message content, or relay metadata, then
+      // update the server.
+      for (const room of decrypted) {
+        if (room.type === 'group' && (!room.name || room.name === 'Group')) {
+          const msgs = ws.messages[room.id] || []
+          let foundName = null
+
+          // Check for subject field in stored messages (newer messages first)
+          for (let i = msgs.length - 1; i >= 0; i--) {
+            if (msgs[i].subject) { foundName = msgs[i].subject; break }
+          }
+
+          // Fallback: parse "Changed group name to X" from message content
+          if (!foundName) {
+            for (let i = msgs.length - 1; i >= 0; i--) {
+              const content = msgs[i].content || ''
+              const match = content.match(/(?:Changed group name to|GroupRenamedTo)\s*[""'](.+?)[""']/i)
+                || content.match(/(?:Changed group name to|GroupRenamedTo)\s+(.+)/i)
+              if (match) { foundName = match[1].trim(); break }
+            }
+          }
+
+          if (foundName) {
+            await updateRoomOnServer(room.id, { name: foundName })
+            debouncedRefetchRooms(dispatch)
+          } else {
+            // Fallback: fetch metadata from relay
+            dispatch('fetchGroupMetadata', { roomId: room.id }).then(async meta => {
+              if (meta?.name) {
+                await updateRoomOnServer(room.id, { name: meta.name })
+                debouncedRefetchRooms(dispatch)
+              }
+            }).catch(() => {})
+          }
+        }
+      }
+    }
+  } catch (err) {
+    debug('fetchRooms error:', err)
+  }
+}
+
+export async function fetchArchivedRooms () {
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return []
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiGet(baseUrl, `/api/nostr/rooms/?wallet_hash=${walletHash}&archived=true`)
+    if (!response.ok) {
+      debug('fetchArchivedRooms failed:', response.status)
+      return []
+    }
+    const data = await response.json()
+    return await decryptRoomsList(data.rooms || [])
+  } catch (err) {
+    debug('fetchArchivedRooms error:', err)
+    return []
+  }
+}
+
+async function syncRoomToServer (room) {
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) { debug('syncRoomToServer: no wallet hash'); return }
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiPost(baseUrl, '/api/nostr/rooms/', {
+      wallet_hash: walletHash,
+      room: {
+        room_id: room.id,
+        type: room.type,
+        name: await encryptRoomName(room.name || 'Group'),
+        members: room.members,
+        subject: room.subject,
+        created_at: new Date(room.createdAt * 1000).toISOString(),
+        updated_at: new Date(room.updatedAt * 1000).toISOString(),
+      },
+    })
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      debug('syncRoomToServer failed:', response.status, body)
+    }
+  } catch (err) {
+    debug('syncRoomToServer error:', err)
+  }
+}
+
+async function updateRoomOnServer (roomId, fields) {
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) { debug('updateRoomOnServer: no wallet hash'); return }
+    const baseUrl = getWatchtowerBaseUrl()
+    const patched = { ...fields }
+    if (patched.name) patched.name = await encryptRoomName(patched.name)
+    const response = await apiPatch(baseUrl, `/api/nostr/rooms/${roomId}/`, {
+      wallet_hash: walletHash,
+      ...patched,
+    })
+    if (!response.ok) debug('updateRoomOnServer failed:', response.status)
+  } catch (err) {
+    debug('updateRoomOnServer error:', err)
+  }
+}
+
+async function touchRoomOnServer (roomId, timestamp) {
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) { debug('touchRoomOnServer: no wallet hash'); return }
+    const baseUrl = getWatchtowerBaseUrl()
+    const body = { wallet_hash: walletHash }
+    if (timestamp) body.timestamp = timestamp
+    const response = await apiPost(baseUrl, `/api/nostr/rooms/${roomId}/touch/`, body)
+    if (!response.ok) debug('touchRoomOnServer failed:', response.status)
+  } catch (err) {
+    debug('touchRoomOnServer error:', err)
+  }
+}
+
+async function deleteRoomOnServer (roomId) {
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) { debug('deleteRoomOnServer: no wallet hash'); return }
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiDelete(baseUrl, `/api/nostr/rooms/${roomId}/`, { wallet_hash: walletHash })
+    if (!response.ok) debug('deleteRoomOnServer failed:', response.status)
+  } catch (err) {
+    debug('deleteRoomOnServer error:', err)
+  }
+}
+
+export async function fetchBlocks ({ commit }) {
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return { blockedContacts: [], blockedGroups: [] }
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiGet(baseUrl, `/api/nostr/blocks/?wallet_hash=${walletHash}`)
+    if (!response.ok) {
+      debug('fetchBlocks failed:', response.status)
+      return { blockedContacts: [], blockedGroups: [] }
+    }
+    const data = await response.json()
+    commit('SET_BLOCKED_CONTACTS', data.blocked_contacts || [])
+    commit('SET_BLOCKED_GROUPS', data.blocked_groups || [])
+    return data
+  } catch (err) {
+    debug('fetchBlocks error:', err)
+    return { blockedContacts: [], blockedGroups: [] }
+  }
+}
+
+export async function blockContact ({ commit }, pubKeyHex) {
+  commit('BLOCK_CONTACT', pubKeyHex)
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiPost(baseUrl, '/api/nostr/blocks/contacts/', {
+      wallet_hash: walletHash,
+      pub_key_hex: pubKeyHex,
+    })
+    if (!response.ok) debug('blockContact failed:', response.status)
+  } catch (err) {
+    debug('blockContact error:', err)
+  }
+}
+
+export async function unblockContact ({ commit }, pubKeyHex) {
+  commit('UNBLOCK_CONTACT', pubKeyHex)
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiDelete(baseUrl, `/api/nostr/blocks/contacts/${pubKeyHex}/`, { wallet_hash: walletHash })
+    if (!response.ok) debug('unblockContact failed:', response.status)
+  } catch (err) {
+    debug('unblockContact error:', err)
+  }
+}
+
+export async function blockGroup ({ commit }, roomId) {
+  commit('BLOCK_GROUP', roomId)
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiPost(baseUrl, '/api/nostr/blocks/groups/', {
+      wallet_hash: walletHash,
+      room_id: roomId,
+    })
+    if (!response.ok) debug('blockGroup failed:', response.status)
+  } catch (err) {
+    debug('blockGroup error:', err)
+  }
+}
+
+export async function unblockGroup ({ commit }, roomId) {
+  commit('UNBLOCK_GROUP', roomId)
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return
+    const baseUrl = getWatchtowerBaseUrl()
+    const response = await apiDelete(baseUrl, `/api/nostr/blocks/groups/${roomId}/`, { wallet_hash: walletHash })
+    if (!response.ok) debug('unblockGroup failed:', response.status)
+  } catch (err) {
+    debug('unblockGroup error:', err)
+  }
+}
+
+export async function createPrivateRoom ({ commit, getters, state }, contactNpub) {
   const ws = getWalletState(state)
   const contact = getters.getContactByNpub(contactNpub)
   if (!contact) throw new Error('Contact not found')
@@ -1103,6 +1546,7 @@ export function createPrivateRoom ({ commit, getters, state }, contactNpub) {
   }
 
   commit('ADD_ROOM', room)
+  syncRoomToServer(room)
   return room
 }
 
@@ -1128,7 +1572,7 @@ export async function createGroupRoom ({ commit, state }, { name, members, subje
   const room = {
     id: roomId,
     type: 'group',
-    name: name || subject || 'Group',
+    name: (name || subject || 'Group').slice(0, MAX_ROOM_NAME_LENGTH),
     members: allMembers,
     subject: subject || null,
     createdAt: Math.floor(Date.now() / 1000),
@@ -1136,6 +1580,7 @@ export async function createGroupRoom ({ commit, state }, { name, members, subje
   }
 
   commit('ADD_ROOM', room)
+  syncRoomToServer(room)
   return room
 }
 
@@ -1300,7 +1745,8 @@ export async function leaveGroup ({ commit, dispatch, state }, { roomId }) {
   commit('ADD_MESSAGE', { roomId: msgRoomId, message })
   await dispatch('publishGiftWraps', { giftWraps })
 
-  commit('BLOCK_GROUP', roomId)
+  await dispatch('blockGroup', roomId)
+  await updateRoomOnServer( roomId, { archived: true })
   commit('ARCHIVE_ROOM', roomId)
 }
 
@@ -1309,7 +1755,8 @@ export async function rejoinGroup ({ commit, dispatch, state }, { roomId }) {
   const room = ws.rooms.find(r => r.id === roomId)
   if (!room) throw new Error('Room not found')
 
-  commit('UNBLOCK_GROUP', roomId)
+  await dispatch('unblockGroup', roomId)
+  await updateRoomOnServer( roomId, { archived: false })
   commit('UNARCHIVE_ROOM', roomId)
 
   try {
@@ -1351,6 +1798,97 @@ export async function rejoinGroup ({ commit, dispatch, state }, { roomId }) {
   } catch (err) {
     console.warn('[Nostr] Failed to send rejoin notification:', err)
   }
+}
+
+// ── Room lifecycle actions (sync to server) ──────────────────────────
+
+export async function archiveRoom ({ commit }, roomId) {
+  commit('ARCHIVE_ROOM', roomId)
+  await updateRoomOnServer( roomId, { archived: true })
+}
+
+export async function unarchiveRoom ({ commit }, roomId) {
+  commit('UNARCHIVE_ROOM', roomId)
+  await updateRoomOnServer( roomId, { archived: false })
+}
+
+export async function updateRoomName ({ commit }, { roomId, name }) {
+  const truncated = name && name.length > MAX_ROOM_NAME_LENGTH ? name.slice(0, MAX_ROOM_NAME_LENGTH) : name
+  commit('UPDATE_ROOM_NAME', { roomId, name: truncated })
+  await updateRoomOnServer(roomId, { name: truncated })
+}
+
+export async function updateRoomSubject ({ commit }, { roomId, subject }) {
+  commit('UPDATE_ROOM_SUBJECT', { roomId, subject })
+  await updateRoomOnServer( roomId, { subject })
+}
+
+export async function touchRoom ({ dispatch }, { roomId, timestamp } = {}) {
+  await touchRoomOnServer(roomId, timestamp)
+  // Re-fetch the room list from the server so ordering updates
+  // authoritatively — no local lastMessageAt mutation that would
+  // cause intermediate reordering.
+  debouncedRefetchRooms(dispatch)
+}
+
+export async function deleteRoom ({ commit }, roomId) {
+  commit('REMOVE_ROOM', roomId)
+  await deleteRoomOnServer(roomId)
+}
+
+// Seed room objects from persisted messages when server returns no rooms.
+// This handles the migration for existing users whose room lists were in local
+// storage but are now managed server-side. Reconstructs minimal room objects
+// from message sender data and syncs them to the server.
+export async function seedRoomsFromMessages ({ commit, dispatch, state }) {
+  const ws = getWalletState(state)
+  const myPubKey = ws.keys?.pubKeyHex
+  if (!myPubKey) return
+  if (!ws.messages || typeof ws.messages !== 'object') return
+
+  const existingRoomIds = new Set(ws.rooms.map(r => r.id))
+  const now = Math.floor(Date.now() / 1000)
+
+  for (const roomId of Object.keys(ws.messages)) {
+    if (existingRoomIds.has(roomId)) continue
+    const msgs = ws.messages[roomId]
+    if (!msgs || !msgs.length) continue
+
+    // Collect unique message senders (excluding self)
+    const senders = [...new Set(msgs.map(m => m.sender).filter(s => s && s !== myPubKey))]
+
+    // Only seed DM rooms (2-person). Group classification from message
+    // senders alone is unreliable — only 1 other member may have spoken,
+    // causing the room to be misclassified as a DM and flip-flopping
+    // between member name/avatar and group name. Groups will be created
+    // by receiveMessage when a new message arrives from any member.
+    if (senders.length > 1) continue
+
+    if (!senders[0]) continue
+
+    const members = [myPubKey, senders[0]]
+
+    const contact = state.contacts.find(c => c.pubKeyHex === senders[0])
+    const name = contact?.name || senders[0].slice(0, 12) + '...'
+
+    const firstMsg = msgs[0]
+    const lastMsg = msgs[msgs.length - 1]
+
+    const room = {
+      id: roomId,
+      type: 'private',
+      name,
+      members,
+      subject: null,
+      createdAt: firstMsg.created_at || now,
+      updatedAt: lastMsg.created_at || now,
+    }
+
+    syncRoomToServer(room)
+  }
+
+  // Re-fetch the room list from the server after seeding
+  dispatch('fetchRooms').catch(() => {})
 }
 
 export async function sendDeleteMessage ({ state }, { roomId, messageId }) {
@@ -1578,8 +2116,10 @@ export async function publishGiftWraps ({ state }, { giftWraps }) {
   await relayService.publish(Array.from(targetRelays), giftWraps)
 }
 
-export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
+export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey }) {
   const ws = getWalletState(state)
+  if (!ws.keys?.pubKeyHex) return
+
   // NIP-17 seal pubkey verification is performed inside unwrapGiftWrap().
   // If we reach here, the rumor has already been verified.
 
@@ -1695,8 +2235,7 @@ export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
     let room = ws.rooms.find(r => r.id === roomId)
     if (!room) {
       if (ws.blockedContacts?.includes(rumor.pubkey)) return
-      const deletedEntry = ws.deletedRooms?.[roomId]
-      if (deletedEntry?.knownMessageIds?.[rumor.id]) return
+      if (ws.deletedRooms?.includes(roomId)) return
       const isGroup = roomMembers.length > 2
       const contact = state.contacts.find(c => c.pubKeyHex === rumor.pubkey)
       room = {
@@ -1708,19 +2247,22 @@ export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
         createdAt: rumor.created_at,
         updatedAt: rumor.created_at,
       }
-      commit('ADD_ROOM', room)
+      // The room is unknown locally — sync it to the server and re-fetch
+      // the room list rather than creating it here. Messages for unknown
+      // rooms are stored so they appear once the room list is refreshed.
+      syncRoomToServer(room)
+      debouncedRefetchRooms(dispatch)
 
+      // For groups, fetch metadata from relay and update the server with
+      // the real name (without mutating local room state).
       if (isGroup) {
-        dispatch('fetchGroupMetadata', { roomId }).then(meta => {
+        dispatch('fetchGroupMetadata', { roomId }).then(async meta => {
           if (meta?.name) {
-            commit('UPDATE_ROOM_NAME', { roomId, name: meta.name })
+            await updateRoomOnServer(roomId, { name: meta.name })
+            debouncedRefetchRooms(dispatch)
           }
         }).catch(() => {})
-        fetchMemberDisplayNames(dispatch, roomMembers)
       }
-      if (ws.deletedRooms?.[roomId]) commit('DELETE_ROOM_TRACKER', roomId)
-    } else if (room.type !== 'group' && roomMembers.length > 2) {
-      commit('UPDATE_ROOM_TYPE', { roomId, type: 'group' })
     }
 
     const replyTo = rumor.tags.find(t => t[0] === 'e')?.[1] || null
@@ -1751,6 +2293,7 @@ export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
     }
 
     commit('ADD_MESSAGE', { roomId, message })
+    queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
     return
   }
 
@@ -1773,8 +2316,7 @@ export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
       (r.members || []).slice().sort().join(',') === memberKey
     )
     if (existingByMembers) {
-      const deletedEntry = ws.deletedRooms?.[existingByMembers.id]
-      if (deletedEntry?.knownMessageIds?.[rumor.id]) return
+      if (ws.deletedRooms?.includes(existingByMembers.id)) return
       // Reuse the existing room — store the message under its ID
       room = existingByMembers
       // Drop messages for a group we've left (blocked) — the stored room id
@@ -1784,17 +2326,6 @@ export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
       const hasSubjectTag = rumor.tags.some(t => t[0] === 'subject')
       const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
       const subject = hasSubjectTag ? (subjectRaw ?? '') : null
-      if (hasSubjectTag && room.subject !== subject && (room.subject === null || rumor.created_at >= (room.updatedAt || 0))) {
-        commit('UPDATE_ROOM_SUBJECT', { roomId: room.id, subject: subject || null })
-        if (!subject && room.type !== 'group') {
-          const memberPubKeys = (room.members || []).filter(pk => pk !== ws.keys?.pubKeyHex)
-          const otherPubKey = memberPubKeys[0]
-          const contact = state.contacts.find(c => c.pubKeyHex === otherPubKey)
-          if (contact?.name) {
-            commit('UPDATE_ROOM_NAME', { roomId: room.id, name: contact.name })
-          }
-        }
-      }
       const msg = {
         id: rumor.id,
         content: rumor.content,
@@ -1805,61 +2336,60 @@ export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
         subject,
       }
       commit('ADD_MESSAGE', { roomId: room.id, message: msg })
+      queueRoomTouch(dispatch, room.id, new Date(rumor.created_at * 1000).toISOString())
       return
     }
 
     // Skip auto-creation if the sender is blocked
     if (ws.blockedContacts?.includes(rumor.pubkey)) return
 
-    const deletedEntry = ws.deletedRooms?.[roomId]
-    if (deletedEntry?.knownMessageIds?.[rumor.id]) return
+    if (ws.deletedRooms?.includes(roomId)) return
 
-    const isGroup = roomMembers.length > 2
-    const contact = state.contacts.find(c => c.pubKeyHex === rumor.pubkey)
-    room = {
+    // The room is unknown locally — sync it to the server and re-fetch
+    // the room list rather than creating it here. Store the message so
+    // it appears once the room list is refreshed, then return early
+    // (skip subject/edit processing that depends on a local room).
+    const isGroupRoom = roomMembers.length > 2
+    const roomForSync = {
       id: roomId,
-      type: isGroup ? 'group' : 'private',
-      name: isGroup ? '' : (contact?.name || rumor.pubkey.slice(0, 12) + '...'),
+      type: isGroupRoom ? 'group' : 'private',
+      name: '',
       members: roomMembers,
       subject: null,
       createdAt: rumor.created_at,
       updatedAt: rumor.created_at,
     }
-    commit('ADD_ROOM', room)
-    if (isGroup) {
-      dispatch('fetchGroupMetadata', { roomId }).then(meta => {
+    syncRoomToServer(roomForSync)
+    debouncedRefetchRooms(dispatch)
+
+    // For groups, fetch metadata from relay and update the server with
+    // the real name (without mutating local room state).
+    if (isGroupRoom) {
+      dispatch('fetchGroupMetadata', { roomId }).then(async meta => {
         if (meta?.name) {
-          commit('UPDATE_ROOM_NAME', { roomId, name: meta.name })
+          await updateRoomOnServer(roomId, { name: meta.name })
+          debouncedRefetchRooms(dispatch)
         }
       }).catch(() => {})
-      fetchMemberDisplayNames(dispatch, roomMembers)
     }
-  } else if (room.type !== 'group' && roomMembers.length > 2) {
-    // Upgrade existing private room to group if we discover it has more than 2 members
-    commit('UPDATE_ROOM_TYPE', { roomId, type: 'group' })
+
+    const earlyMsg = {
+      id: rumor.id,
+      content: rumor.content,
+      sender: rumor.pubkey,
+      created_at: rumor.created_at,
+      kind14Id: rumor.id,
+      replyTo: null,
+      editOf: null,
+      localReceivedAt: Date.now(),
+    }
+    commit('ADD_MESSAGE', { roomId, message: earlyMsg })
+    queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
+    return
   }
 
   const replyTo = rumor.tags.find(t => t[0] === 'e')?.[1] || null
   const editOf = rumor.tags.find(t => t[0] === 'edit')?.[1] || null
-  const hasSubjectTag = rumor.tags.some(t => t[0] === 'subject')
-  const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
-  const subject = hasSubjectTag ? (subjectRaw ?? '') : null
-
-  // Only apply subject changes from messages that are not older than the
-  // room's current updatedAt. This prevents old messages from re-applying
-  // a subject that was cleared/updated by a newer local action.
-  // Also skip subject updates while the room is in deletedRooms (restored from delete).
-  if (hasSubjectTag && room.subject !== subject && (room.subject === null || rumor.created_at >= (room.updatedAt || 0)) && !ws.deletedRooms?.[roomId]) {
-    commit('UPDATE_ROOM_SUBJECT', { roomId, subject: subject || null })
-    if (!subject && room.type !== 'group') {
-      const memberPubKeys = (room.members || []).filter(pk => pk !== ws.keys?.pubKeyHex)
-      const otherPubKey = memberPubKeys[0]
-      const contact = state.contacts.find(c => c.pubKeyHex === otherPubKey)
-      if (contact?.name) {
-        commit('UPDATE_ROOM_NAME', { roomId, name: contact.name })
-      }
-    }
-  }
 
   if (editOf) {
     const originalMsg = (ws.messages[roomId] || []).find(m => m.id === editOf)
@@ -1894,6 +2424,7 @@ export function receiveMessage ({ commit, state }, { rumor, sealPubkey }) {
   }
 
   commit('ADD_MESSAGE', { roomId, message })
+  queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
 
   // Flush any pending read receipts whose message has now arrived
   flushPendingReadReceipts(state, commit)
@@ -2072,6 +2603,10 @@ export function subscribeToRelays ({ state, dispatch, commit }) {
       }
     }, 15000)
   }
+
+  // Fetch room list and blocks from server (authoritative source for room list)
+  dispatch('fetchRooms').catch(() => {})
+  dispatch('fetchBlocks').catch(() => {})
 
   dispatch('startActiveServices')
 

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -36,6 +36,17 @@ function debouncedRefetchRooms (dispatch) {
   }, 2000)
 }
 
+// Fetch group metadata from relay and update the server if a real name is found.
+// Shared by fetchRooms (placeholder recovery) and receiveMessage (new room sync).
+function fetchAndSyncGroupMetadata (dispatch, roomId) {
+  dispatch('fetchGroupMetadata', { roomId }).then(async meta => {
+    if (meta?.name) {
+      await updateRoomOnServer(roomId, { name: meta.name })
+      debouncedRefetchRooms(dispatch)
+    }
+  }).catch(() => {})
+}
+
 function queueRoomTouch (dispatch, roomId, timestamp) {
   _roomTouchPending[roomId] = timestamp
   if (_roomTouchTimers[roomId]) clearTimeout(_roomTouchTimers[roomId])
@@ -158,6 +169,10 @@ export async function reinitialize ({ commit, dispatch, state }) {
   relayService.disconnect()
   commit('SET_SUBSCRIBED', false)
   clearChatCache().catch(err => console.warn('Failed to clear chat cache during reinitialize:', err))
+
+  // Clear cached encryption key — the new wallet has a different mnemonic
+  _roomNameEncryptionKey = null
+  _roomNameEncryptionKeyPromise = null
 
   commit('SET_KEYS', keys)
   commit('SET_READY', true)
@@ -1332,12 +1347,15 @@ export async function fetchRooms ({ commit, dispatch, state }) {
             if (msgs[i].subject) { foundName = msgs[i].subject; break }
           }
 
-          // Fallback: parse "Changed group name to X" from message content
+          // Fallback: parse rename notification from message content.
+          // The rename message format is: "{name} changed group name to \"{new}\""
+          // or translations thereof. Match any text ending with the new name in quotes.
           if (!foundName) {
             for (let i = msgs.length - 1; i >= 0; i--) {
               const content = msgs[i].content || ''
-              const match = content.match(/(?:Changed group name to|GroupRenamedTo)\s*[""'](.+?)[""']/i)
-                || content.match(/(?:Changed group name to|GroupRenamedTo)\s+(.+)/i)
+              // Look for the last quoted segment after "name to" or similar patterns
+              const match = content.match(/name\s+to\s+["""''`](.+?)["""''`]/i)
+                || content.match(/.+?["""''`](.+?)["""''`]/)
               if (match) { foundName = match[1].trim(); break }
             }
           }
@@ -1346,37 +1364,13 @@ export async function fetchRooms ({ commit, dispatch, state }) {
             await updateRoomOnServer(room.id, { name: foundName })
             debouncedRefetchRooms(dispatch)
           } else {
-            // Fallback: fetch metadata from relay
-            dispatch('fetchGroupMetadata', { roomId: room.id }).then(async meta => {
-              if (meta?.name) {
-                await updateRoomOnServer(room.id, { name: meta.name })
-                debouncedRefetchRooms(dispatch)
-              }
-            }).catch(() => {})
+            fetchAndSyncGroupMetadata(dispatch, room.id)
           }
         }
       }
     }
   } catch (err) {
     debug('fetchRooms error:', err)
-  }
-}
-
-export async function fetchArchivedRooms () {
-  try {
-    const walletHash = getCurrentWalletHash()
-    if (!walletHash) return []
-    const baseUrl = getWatchtowerBaseUrl()
-    const response = await apiGet(baseUrl, `/api/nostr/rooms/?wallet_hash=${walletHash}&archived=true`)
-    if (!response.ok) {
-      debug('fetchArchivedRooms failed:', response.status)
-      return []
-    }
-    const data = await response.json()
-    return await decryptRoomsList(data.rooms || [])
-  } catch (err) {
-    debug('fetchArchivedRooms error:', err)
-    return []
   }
 }
 
@@ -1392,7 +1386,7 @@ async function syncRoomToServer (room) {
         type: room.type,
         name: await encryptRoomName(room.name || 'Group'),
         members: room.members,
-        subject: room.subject,
+        subject: room.subject ? await encryptRoomName(room.subject) : room.subject,
         created_at: new Date(room.createdAt * 1000).toISOString(),
         updated_at: new Date(room.updatedAt * 1000).toISOString(),
       },
@@ -1413,6 +1407,7 @@ async function updateRoomOnServer (roomId, fields) {
     const baseUrl = getWatchtowerBaseUrl()
     const patched = { ...fields }
     if (patched.name) patched.name = await encryptRoomName(patched.name)
+    if (patched.subject) patched.subject = await encryptRoomName(patched.subject)
     const response = await apiPatch(baseUrl, `/api/nostr/rooms/${roomId}/`, {
       wallet_hash: walletHash,
       ...patched,
@@ -1546,7 +1541,7 @@ export async function createPrivateRoom ({ commit, getters, state }, contactNpub
   }
 
   commit('ADD_ROOM', room)
-  syncRoomToServer(room)
+  await syncRoomToServer(room)
   return room
 }
 
@@ -1580,7 +1575,7 @@ export async function createGroupRoom ({ commit, state }, { name, members, subje
   }
 
   commit('ADD_ROOM', room)
-  syncRoomToServer(room)
+  await syncRoomToServer(room)
   return room
 }
 
@@ -2256,12 +2251,7 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
       // For groups, fetch metadata from relay and update the server with
       // the real name (without mutating local room state).
       if (isGroup) {
-        dispatch('fetchGroupMetadata', { roomId }).then(async meta => {
-          if (meta?.name) {
-            await updateRoomOnServer(roomId, { name: meta.name })
-            debouncedRefetchRooms(dispatch)
-          }
-        }).catch(() => {})
+        fetchAndSyncGroupMetadata(dispatch, roomId)
       }
     }
 
@@ -2303,6 +2293,8 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
   const pTags = rumor.tags.filter(t => t[0] === 'p').map(t => t[1])
   const roomMembers = [...new Set([myPubKey, rumor.pubkey, ...pTags])]
   const roomId = computeRoomId(roomMembers)
+  const replyTo = rumor.tags.find(t => t[0] === 'e')?.[1] || null
+  const editOf = rumor.tags.find(t => t[0] === 'edit')?.[1] || null
 
   // Drop messages for a group we've left (blocked)
   if (ws.blockedGroups?.includes(roomId)) return
@@ -2317,12 +2309,13 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
     )
     if (existingByMembers) {
       if (ws.deletedRooms?.includes(existingByMembers.id)) return
+      // Drop messages for a blocked sender
+      if (ws.blockedContacts?.includes(rumor.pubkey)) return
       // Reuse the existing room — store the message under its ID
       room = existingByMembers
       // Drop messages for a group we've left (blocked) — the stored room id
       // may differ from the computed roomId when legacy rooms exist.
       if (ws.blockedGroups?.includes(room.id)) return
-      const replyTo = rumor.tags.find(t => t[0] === 'e')?.[1] || null
       const hasSubjectTag = rumor.tags.some(t => t[0] === 'subject')
       const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
       const subject = hasSubjectTag ? (subjectRaw ?? '') : null
@@ -2365,12 +2358,7 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
     // For groups, fetch metadata from relay and update the server with
     // the real name (without mutating local room state).
     if (isGroupRoom) {
-      dispatch('fetchGroupMetadata', { roomId }).then(async meta => {
-        if (meta?.name) {
-          await updateRoomOnServer(roomId, { name: meta.name })
-          debouncedRefetchRooms(dispatch)
-        }
-      }).catch(() => {})
+      fetchAndSyncGroupMetadata(dispatch, roomId)
     }
 
     const earlyMsg = {
@@ -2379,17 +2367,14 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
       sender: rumor.pubkey,
       created_at: rumor.created_at,
       kind14Id: rumor.id,
-      replyTo: null,
-      editOf: null,
+      replyTo,
+      editOf,
       localReceivedAt: Date.now(),
     }
     commit('ADD_MESSAGE', { roomId, message: earlyMsg })
     queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
     return
   }
-
-  const replyTo = rumor.tags.find(t => t[0] === 'e')?.[1] || null
-  const editOf = rumor.tags.find(t => t[0] === 'edit')?.[1] || null
 
   if (editOf) {
     const originalMsg = (ws.messages[roomId] || []).find(m => m.id === editOf)
@@ -2605,7 +2590,10 @@ export function subscribeToRelays ({ state, dispatch, commit }) {
   }
 
   // Fetch room list and blocks from server (authoritative source for room list)
-  dispatch('fetchRooms').catch(() => {})
+  // If the server has no rooms yet (migration), seed from local messages.
+  dispatch('fetchRooms').catch(() => {}).then(() => {
+    dispatch('seedRoomsFromMessages').catch(() => {})
+  })
   dispatch('fetchBlocks').catch(() => {})
 
   dispatch('startActiveServices')

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -1347,21 +1347,6 @@ export async function fetchRooms ({ commit, dispatch, state }) {
             if (msgs[i].subject) { foundName = msgs[i].subject; break }
           }
 
-          // Fallback: parse rename notification from message content.
-          // Rename messages follow the pattern "{who} changed group name to \"{new}\""
-          // (or localized equivalent). The name always appears in the last quoted
-          // segment and the message contains "change" or "rename" keywords.
-          if (!foundName) {
-            for (let i = msgs.length - 1; i >= 0; i--) {
-              const content = msgs[i].content || ''
-              const hasRename = /change|rename|renamed|changed|renamed/i.test(content)
-              if (!hasRename) continue
-              const match = content.match(/["""''`](.+?)["""''`]\s*$/)
-                || content.match(/["""''`](.+?)["""''`]/)
-              if (match) { foundName = match[1].trim(); break }
-            }
-          }
-
           if (foundName) {
             await updateRoomOnServer(room.id, { name: foundName })
             debouncedRefetchRooms(dispatch)
@@ -1845,6 +1830,7 @@ export async function seedRoomsFromMessages ({ commit, dispatch, state }) {
 
   const existingRoomIds = new Set(ws.rooms.map(r => r.id))
   const now = Math.floor(Date.now() / 1000)
+  const syncPromises = []
 
   for (const roomId of Object.keys(ws.messages)) {
     if (existingRoomIds.has(roomId)) continue
@@ -1881,8 +1867,10 @@ export async function seedRoomsFromMessages ({ commit, dispatch, state }) {
       updatedAt: lastMsg.created_at || now,
     }
 
-    syncRoomToServer(room)
+    syncPromises.push(syncRoomToServer(room))
   }
+
+  await Promise.allSettled(syncPromises)
 
   // Re-fetch the room list from the server after seeding
   dispatch('fetchRooms').catch(() => {})
@@ -2374,6 +2362,8 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
       editOf,
       localReceivedAt: Date.now(),
     }
+    const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
+    if (subjectRaw !== undefined) earlyMsg.subject = subjectRaw
     commit('ADD_MESSAGE', { roomId, message: earlyMsg })
     queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
     return
@@ -2410,6 +2400,10 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
     editOf,
     localReceivedAt: Date.now(),
   }
+
+  // Store subject tag if present — used for group name recovery
+  const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
+  if (subjectRaw !== undefined) message.subject = subjectRaw
 
   commit('ADD_MESSAGE', { roomId, message })
   queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
@@ -2624,14 +2618,14 @@ export function ensureSubscribed ({ dispatch, getters }) {
   // Ensure we have keys (including privKeyHex which is stripped from persisted state)
   // and an active relay subscription, especially after app backgrounding or push
   if (!getters['isInitialized'] || !getters['myPrivKey']) {
-    dispatch('initialize').then(() => {
-      dispatch('subscribeToRelays')
+    return dispatch('initialize').then(() => {
+      return dispatch('subscribeToRelays')
     }).catch(err => {
       console.warn('[Nostr] Failed to initialize, clearing cooldown for retry:', err)
       _lastEnsureTime = 0
     })
   } else {
-    dispatch('subscribeToRelays')
+    return dispatch('subscribeToRelays')
   }
 }
 

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -1840,14 +1840,12 @@ export async function seedRoomsFromMessages ({ commit, dispatch, state }) {
     // Collect unique message senders (excluding self)
     const senders = [...new Set(msgs.map(m => m.sender).filter(s => s && s !== myPubKey))]
 
-    // Only seed DM rooms (2-person). Group classification from message
-    // senders alone is unreliable — only 1 other member may have spoken,
-    // causing the room to be misclassified as a DM and flip-flopping
-    // between member name/avatar and group name. Groups will be created
-    // by receiveMessage when a new message arrives from any member.
-    if (senders.length > 1) continue
-
-    if (!senders[0]) continue
+    // Only seed DM rooms (2-person). Skip one-sided DMs (senders.length === 0,
+    // meaning only self messages) — the other party's pubkey can't be determined
+    // from message data alone, so the room would be malformed. These rooms will
+    // be created normally when the user next opens the conversation.
+    // Also skip groups (senders.length > 1) — see comment above.
+    if (senders.length !== 1) continue
 
     const members = [myPubKey, senders[0]]
 
@@ -2309,17 +2307,36 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
       const hasSubjectTag = rumor.tags.some(t => t[0] === 'subject')
       const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
       const subject = hasSubjectTag ? (subjectRaw ?? '') : null
-      const msg = {
-        id: rumor.id,
-        content: rumor.content,
-        sender: rumor.pubkey,
-        created_at: rumor.created_at,
-        roomId: room.id,
-        replyTo,
-        subject,
-        editOf,
+      if (editOf) {
+        // Edit targeting an existing message — update in place
+        const target = (ws.messages[room.id] || []).find(m => m.id === editOf)
+        if (target) {
+          commit('UPDATE_MESSAGE', { roomId: room.id, messageId: editOf, newContent: rumor.content })
+        } else {
+          const msg = {
+            id: rumor.id,
+            content: rumor.content,
+            sender: rumor.pubkey,
+            created_at: rumor.created_at,
+            roomId: room.id,
+            replyTo,
+            subject,
+            editOf,
+          }
+          commit('ADD_MESSAGE', { roomId: room.id, message: msg })
+        }
+      } else {
+        const msg = {
+          id: rumor.id,
+          content: rumor.content,
+          sender: rumor.pubkey,
+          created_at: rumor.created_at,
+          roomId: room.id,
+          replyTo,
+          subject,
+        }
+        commit('ADD_MESSAGE', { roomId: room.id, message: msg })
       }
-      commit('ADD_MESSAGE', { roomId: room.id, message: msg })
       queueRoomTouch(dispatch, room.id, new Date(rumor.created_at * 1000).toISOString())
       return
     }
@@ -2605,12 +2622,13 @@ export function ensureSubscribed ({ dispatch, getters }) {
   const now = Date.now()
 
   // Debounce: skip if we ensured recently
-  if ((now - _lastEnsureTime) < ENSURE_COOLDOWN_MS) return
+  if ((now - _lastEnsureTime) < ENSURE_COOLDOWN_MS) return Promise.resolve()
   _lastEnsureTime = now
 
-  // Always re-register pubkey-to-wallet mapping when chat opens
-  // This ensures the pubkey stays registered in Watchtower
-  dispatch('registerNostrPubkey')
+  // Always re-register pubkey-to-wallet mapping when chat opens.
+  // This ensures the pubkey stays registered in Watchtower. Chained into
+  // the returned promise so callers can rely on full setup completion.
+  return dispatch('registerNostrPubkey').then(() => {
 
   // Skip if already subscribed and not stale
   if (relayService.isSubscribed() && getters['isInitialized'] && getters['myPrivKey']) return
@@ -2620,13 +2638,14 @@ export function ensureSubscribed ({ dispatch, getters }) {
   if (!getters['isInitialized'] || !getters['myPrivKey']) {
     return dispatch('initialize').then(() => {
       return dispatch('subscribeToRelays')
-    }).catch(err => {
-      console.warn('[Nostr] Failed to initialize, clearing cooldown for retry:', err)
-      _lastEnsureTime = 0
     })
   } else {
     return dispatch('subscribeToRelays')
   }
+  }).catch(err => {
+    console.warn('[Nostr] Failed to initialize, clearing cooldown for retry:', err)
+    _lastEnsureTime = 0
+  })
 }
 
 // NOTE: A `disconnectRelays` action previously lived here but had no callers

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -1113,6 +1113,7 @@ export function stopActiveServices () {
     _heartbeatInterval = null
   }
   stopActiveWs()
+  clearDebouncedTimers()
 }
 
 export async function setShowActiveStatus ({ commit, dispatch, getters, rootGetters }, value) {
@@ -1301,13 +1302,13 @@ async function encryptRoomName (name) {
   if (!name) return name
   try {
     const key = await getRoomNameEncryptionKey()
-    if (!key) { debug('encryptRoomName: no encryption key — storing name in plaintext'); return name }
+    if (!key) { console.warn('[Nostr] encryptRoomName: no encryption key — storing name in plaintext'); return name }
     const truncated = name.length > MAX_ROOM_NAME_LENGTH
       ? name.slice(0, MAX_ROOM_NAME_LENGTH)
       : name
     return nip44.encrypt(truncated, key)
   } catch (err) {
-    debug('encryptRoomName: encryption failed — storing name in plaintext:', err?.message)
+    console.warn('[Nostr] encryptRoomName: encryption failed — storing name in plaintext:', err?.message)
     return name
   }
 }

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -1021,7 +1021,7 @@ export function stopActiveServices () {
   stopActiveWs()
 }
 
-export function setShowActiveStatus ({ commit, dispatch, getters }, value) {
+export async function setShowActiveStatus ({ commit, dispatch, getters, rootGetters }, value) {
   commit('SET_SHOW_ACTIVE_STATUS', value)
   if (value && _activeServicesRunning) {
     startPubkeyRegistrationHeartbeat(dispatch)
@@ -1030,6 +1030,57 @@ export function setShowActiveStatus ({ commit, dispatch, getters }, value) {
       clearInterval(_heartbeatInterval)
       _heartbeatInterval = null
     }
+  }
+
+  try {
+    const walletHash = getCurrentWalletHash()
+    if (!walletHash) return
+
+    const isChipnet = rootGetters['global/isChipnet']
+    const baseUrl = isChipnet ? 'https://chipnet.watchtower.cash' : 'https://watchtower.cash'
+    const authHeaders = await getAuthHeaders()
+
+    async function doPost () {
+      const headers = await getAuthHeaders()
+      return fetch(`${baseUrl}/api/nostr/active-status/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        body: JSON.stringify({
+          wallet_hash: walletHash,
+          show_active_status: value,
+        }),
+      })
+    }
+
+    const response = await doPost()
+    if (response.status === 401) {
+      await clearToken()
+      const retryResponse = await doPost()
+      if (!retryResponse.ok) {
+        debug('setShowActiveStatus failed after token refresh:', retryResponse.status)
+        return
+      }
+      const data = await retryResponse.json()
+      if (data.show_active_status !== undefined) {
+        commit('SET_SHOW_ACTIVE_STATUS', data.show_active_status)
+      }
+      return
+    }
+
+    if (!response.ok) {
+      debug('setShowActiveStatus failed:', response.status)
+      return
+    }
+
+    const data = await response.json()
+    if (data.show_active_status !== undefined) {
+      commit('SET_SHOW_ACTIVE_STATUS', data.show_active_status)
+    }
+  } catch (err) {
+    debug('setShowActiveStatus error:', err)
   }
 }
 

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -74,6 +74,20 @@ function flushAllRoomTouches (dispatch) {
   }
 }
 
+function clearDebouncedTimers () {
+  for (const roomId of Object.keys(_roomTouchTimers)) {
+    clearTimeout(_roomTouchTimers[roomId])
+    delete _roomTouchTimers[roomId]
+  }
+  for (const roomId of Object.keys(_roomTouchPending)) {
+    delete _roomTouchPending[roomId]
+  }
+  if (_refetchRoomsTimer) {
+    clearTimeout(_refetchRoomsTimer)
+    _refetchRoomsTimer = null
+  }
+}
+
 function flushPendingReadReceipts (state, commit) {
   if (!_pendingReadReceipts.size) return
   const ws = getWalletState(state)
@@ -157,6 +171,10 @@ export async function reinitialize ({ commit, dispatch, state }) {
   if (!walletHash) return
   const mnemonic = await getMnemonicByHash(walletHash)
   if (!mnemonic) return
+
+  // Clear debounced timers from the previous wallet session to prevent
+  // stale touchRoom/fetchRooms dispatches against the new wallet state.
+  clearDebouncedTimers()
 
   const keys = deriveNostrKeys(mnemonic)
   const ws = getWalletState(state)
@@ -2645,6 +2663,7 @@ export function ensureSubscribed ({ dispatch, getters }) {
   }).catch(err => {
     console.warn('[Nostr] Failed to initialize, clearing cooldown for retry:', err)
     _lastEnsureTime = 0
+    throw err
   })
 }
 

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -1305,7 +1305,7 @@ async function decryptRoomsList (rooms) {
       type: r.type,
       name: await decryptRoomName(r.name),
       members: r.members || [],
-      subject: r.subject,
+      subject: await decryptRoomName(r.subject),
       archived: !!r.archived,
       createdAt: typeof createdAt === 'string' ? Math.floor(new Date(createdAt).getTime() / 1000) : createdAt,
       updatedAt: typeof updatedAt === 'string' ? Math.floor(new Date(updatedAt).getTime() / 1000) : updatedAt,
@@ -1348,14 +1348,16 @@ export async function fetchRooms ({ commit, dispatch, state }) {
           }
 
           // Fallback: parse rename notification from message content.
-          // The rename message format is: "{name} changed group name to \"{new}\""
-          // or translations thereof. Match any text ending with the new name in quotes.
+          // Rename messages follow the pattern "{who} changed group name to \"{new}\""
+          // (or localized equivalent). The name always appears in the last quoted
+          // segment and the message contains "change" or "rename" keywords.
           if (!foundName) {
             for (let i = msgs.length - 1; i >= 0; i--) {
               const content = msgs[i].content || ''
-              // Look for the last quoted segment after "name to" or similar patterns
-              const match = content.match(/name\s+to\s+["""''`](.+?)["""''`]/i)
-                || content.match(/.+?["""''`](.+?)["""''`]/)
+              const hasRename = /change|rename|renamed|changed|renamed/i.test(content)
+              if (!hasRename) continue
+              const match = content.match(/["""''`](.+?)["""''`]\s*$/)
+                || content.match(/["""''`](.+?)["""''`]/)
               if (match) { foundName = match[1].trim(); break }
             }
           }
@@ -2327,6 +2329,7 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
         roomId: room.id,
         replyTo,
         subject,
+        editOf,
       }
       commit('ADD_MESSAGE', { roomId: room.id, message: msg })
       queueRoomTouch(dispatch, room.id, new Date(rumor.created_at * 1000).toISOString())

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -15,6 +15,16 @@ const _markRoomLocks = new Set()
 // receiveMessage call.
 const _pendingReadReceipts = new Map()
 
+// Fast lookup: messageId → roomId. Populated by commitAddMessage below so that
+// kind 7 read-receipt processing (Object.keys(ws.messages).find(...)) doesn't
+// scan every room and every message per receipt. Reset on wallet switch.
+const _messageRoomMap = new Map()
+
+function commitAddMessage (commit, roomId, message) {
+  commit('ADD_MESSAGE', { roomId, message })
+  if (message?.id) _messageRoomMap.set(message.id, roomId)
+}
+
 // Per-room debounce timers for touchRoom. During the initial relay sync,
 // messages stream in rapidly — touching the server for every one would be
 // excessive. Instead we debounce: each new message resets a 2s timer for
@@ -175,6 +185,7 @@ export async function reinitialize ({ commit, dispatch, state }) {
   // Clear debounced timers from the previous wallet session to prevent
   // stale touchRoom/fetchRooms dispatches against the new wallet state.
   clearDebouncedTimers()
+  _messageRoomMap.clear()
 
   const keys = deriveNostrKeys(mnemonic)
   const ws = getWalletState(state)
@@ -774,7 +785,7 @@ export async function fetchHistoricalMessages ({ state, dispatch, commit }) {
 
   // Clean up deletedRooms entries for rooms that were restored during the historical fetch.
   // This allows future live messages to apply subject updates normally.
-  for (const roomId of Object.keys(ws.deletedRooms || {})) {
+  for (const roomId of (ws.deletedRooms || [])) {
     if (ws.rooms.some(r => r.id === roomId)) {
       commit('DELETE_ROOM_TRACKER', roomId)
     }
@@ -1290,12 +1301,13 @@ async function encryptRoomName (name) {
   if (!name) return name
   try {
     const key = await getRoomNameEncryptionKey()
-    if (!key) return name
+    if (!key) { debug('encryptRoomName: no encryption key — storing name in plaintext'); return name }
     const truncated = name.length > MAX_ROOM_NAME_LENGTH
       ? name.slice(0, MAX_ROOM_NAME_LENGTH)
       : name
     return nip44.encrypt(truncated, key)
-  } catch {
+  } catch (err) {
+    debug('encryptRoomName: encryption failed — storing name in plaintext:', err?.message)
     return name
   }
 }
@@ -2125,7 +2137,7 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
   // If we reach here, the rumor has already been verified.
 
   // nip59.unwrapEvent returns unsigned rumors without an `id` field.
-  // Compute it so message-based dedup (deletedRooms.knownMessageIds) works.
+  // Compute it so message-based dedup works.
   if (!rumor.id) {
     rumor.id = getEventHash(rumor)
   }
@@ -2141,11 +2153,11 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
     const readerPubKey = rumor.pubkey
 
     if (messageId && readerPubKey) {
-      // Find the room that contains this message — avoids assuming a 2-person room,
-      // which breaks for group chats where computeRoomId needs all member pubkeys.
-      const roomId = Object.keys(ws.messages).find(
-        rid => ws.messages[rid]?.some(m => m.id === messageId)
-      )
+      // Fast lookup via messageId → roomId map; fallback to scan.
+      const roomId = _messageRoomMap.get(messageId)
+        || Object.keys(ws.messages).find(
+          rid => ws.messages[rid]?.some(m => m.id === messageId)
+        )
       if (roomId) {
         commit('SET_MESSAGE_READ_BY', {
           roomId,
@@ -2178,7 +2190,9 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
     if (messageId && reactorPubKey && content) {
       // Find the room that contains this message — avoids assuming a 2-person room,
       // which breaks for group chats where computeRoomId needs all member pubkeys.
-      const roomId = Object.keys(ws.messages).find(
+      // Fast lookup via messageId → roomId map; fallback to scan.
+      const roomId = _messageRoomMap.get(messageId)
+        || Object.keys(ws.messages).find(
         rid => ws.messages[rid]?.some(m => m.id === messageId)
       )
       if (!roomId) return
@@ -2288,7 +2302,7 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
       isFile: true,
     }
 
-    commit('ADD_MESSAGE', { roomId, message })
+    commitAddMessage(commit, roomId, message)
     queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
     return
   }
@@ -2326,22 +2340,14 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
       const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
       const subject = hasSubjectTag ? (subjectRaw ?? '') : null
       if (editOf) {
-        // Edit targeting an existing message — update in place
+        // Edit targeting an existing message — update in place, or skip if
+        // the target is unknown to avoid creating a phantom new message.
         const target = (ws.messages[room.id] || []).find(m => m.id === editOf)
         if (target) {
           commit('UPDATE_MESSAGE', { roomId: room.id, messageId: editOf, newContent: rumor.content })
         } else {
-          const msg = {
-            id: rumor.id,
-            content: rumor.content,
-            sender: rumor.pubkey,
-            created_at: rumor.created_at,
-            roomId: room.id,
-            replyTo,
-            subject,
-            editOf,
-          }
-          commit('ADD_MESSAGE', { roomId: room.id, message: msg })
+          console.warn('[Nostr] Edit targets unknown message', editOf, 'in legacy room — skipping')
+          return
         }
       } else {
         const msg = {
@@ -2353,7 +2359,7 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
           replyTo,
           subject,
         }
-        commit('ADD_MESSAGE', { roomId: room.id, message: msg })
+        commitAddMessage(commit, room.id, msg)
       }
       queueRoomTouch(dispatch, room.id, new Date(rumor.created_at * 1000).toISOString())
       return
@@ -2399,7 +2405,7 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
     }
     const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
     if (subjectRaw !== undefined) earlyMsg.subject = subjectRaw
-    commit('ADD_MESSAGE', { roomId, message: earlyMsg })
+    commitAddMessage(commit, roomId, earlyMsg)
     queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
     return
   }
@@ -2440,9 +2446,9 @@ export function receiveMessage ({ commit, dispatch, state }, { rumor, sealPubkey
   const subjectRaw = rumor.tags.find(t => t[0] === 'subject')?.[1]
   if (subjectRaw !== undefined) message.subject = subjectRaw
 
-  commit('ADD_MESSAGE', { roomId, message })
-  queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
+  commitAddMessage(commit, roomId, message)
 
+  queueRoomTouch(dispatch, roomId, new Date(rumor.created_at * 1000).toISOString())
   // Flush any pending read receipts whose message has now arrived
   flushPendingReadReceipts(state, commit)
 }

--- a/src/store/nostr-chat/getters.js
+++ b/src/store/nostr-chat/getters.js
@@ -82,7 +82,7 @@ export function getRooms (state) {
   if (!myPubKey) return []
   return (ws.rooms || [])
     .filter(r => r.members?.includes(myPubKey) && !r.archived)
-    .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
+    .sort((a, b) => (b.lastMessageAt || 0) - (a.lastMessageAt || 0))
 }
 
 export function getArchivedRooms (state) {
@@ -91,7 +91,7 @@ export function getArchivedRooms (state) {
   if (!myPubKey) return []
   return (ws.rooms || [])
     .filter(r => r.members?.includes(myPubKey) && r.archived)
-    .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
+    .sort((a, b) => (b.lastMessageAt || 0) - (a.lastMessageAt || 0))
 }
 
 export function getRoom (state) {

--- a/src/store/nostr-chat/mutations.js
+++ b/src/store/nostr-chat/mutations.js
@@ -160,15 +160,9 @@ export function UPDATE_ROOM_TYPE (state, { roomId, type }) {
 export function REMOVE_ROOM (state, roomId) {
   const ws = getOrInitWalletState(state)
   if (!ws) return
-  if (!ws.deletedRooms) ws.deletedRooms = {}
-  const messages = ws.messages[roomId] || []
-  const knownMessageIds = {}
-  for (const msg of messages) {
-    if (msg.id) knownMessageIds[msg.id] = true
-  }
-  ws.deletedRooms[roomId] = {
-    deletedAt: Date.now(),
-    knownMessageIds,
+  if (!ws.deletedRooms) ws.deletedRooms = []
+  if (!ws.deletedRooms.includes(roomId)) {
+    ws.deletedRooms.push(roomId)
   }
   ws.rooms = ws.rooms.filter(r => r.id !== roomId)
   delete ws.messages[roomId]
@@ -231,6 +225,23 @@ export function UNBLOCK_GROUP (state, roomId) {
   ws.blockedGroups = ws.blockedGroups.filter(id => id !== roomId)
 }
 
+// ---- Server-backed cache mutations ----
+
+export function SET_BLOCKED_CONTACTS (state, pubKeys) {
+  const ws = getOrInitWalletState(state)
+  if (ws) ws.blockedContacts = pubKeys
+}
+
+export function SET_BLOCKED_GROUPS (state, roomIds) {
+  const ws = getOrInitWalletState(state)
+  if (ws) ws.blockedGroups = roomIds
+}
+
+export function SET_ROOMS (state, rooms) {
+  const ws = getOrInitWalletState(state)
+  if (ws) ws.rooms = rooms
+}
+
 // ---- Per-wallet message mutations ----
 
 export function ADD_MESSAGE (state, { roomId, message }) {
@@ -245,10 +256,8 @@ export function ADD_MESSAGE (state, { roomId, message }) {
     let i = arr.length
     while (i > 0 && arr[i - 1].created_at > message.created_at) i--
     arr.splice(i, 0, message)
-    const room = ws.rooms.find(r => r.id === roomId)
-    if (room) {
-      room.updatedAt = Math.max(room.updatedAt || 0, message.created_at)
-    }
+    // Note: room.updatedAt is NOT updated here — the room list ordering
+    // is driven by lastMessageAt from the server, not by local messages.
   }
 }
 
@@ -453,7 +462,9 @@ export function RESET_PROFILE (state) {
 export function DELETE_ROOM_TRACKER (state, roomId) {
   const ws = getOrInitWalletState(state)
   if (!ws) return
-  if (ws.deletedRooms?.[roomId]) delete ws.deletedRooms[roomId]
+  if (ws.deletedRooms) {
+    ws.deletedRooms = ws.deletedRooms.filter(id => id !== roomId)
+  }
 }
 
 // Reset per-wallet chat data (conversations, caches) but keep keys and profile
@@ -461,7 +472,7 @@ export function RESET_WALLET_CHAT_DATA (state) {
   const ws = getOrInitWalletState(state)
   if (!ws) return
   ws.rooms = []
-  ws.deletedRooms = {}
+  ws.deletedRooms = []
   ws.messages = {}
   ws.readReceipts = {}
   ws.readMessageIds = {}

--- a/src/store/nostr-chat/state.js
+++ b/src/store/nostr-chat/state.js
@@ -11,10 +11,14 @@ export function getInitialWalletState () {
     },
 
     // Conversations (per-wallet)
+    // Active rooms cache (minimal fields: id, type, name, members, subject, updatedAt)
+    // The full room list is stored server-side; this is a lightweight cache for the UI.
     rooms: [],
+    // Server-backed block list caches (re-fetched on init)
     blockedContacts: [],
     blockedGroups: [],
-    deletedRooms: {},
+    // Server-backed deleted room IDs cache (re-fetched on init)
+    deletedRooms: [],
     messages: {},
     readReceipts: {},
     readMessageIds: {},


### PR DESCRIPTION
## Summary

Moves Nostr chat room list storage from Vuex/localStorage to the Watchtower server, making the server the authoritative source for room metadata.

### Key Changes

**Server-authoritative room list:**
- Room list loaded from server via `fetchRooms` on chat init
- Relay messages no longer mutate room objects — `receiveMessage` only stores messages and syncs unknown rooms to the server for a debounced re-fetch
- Room list ordering driven by `last_message_timestamp` from the server only (no local reordering from incoming messages)

**Room name encryption:**
- Group names encrypted with NIP-44 before storing on the server
- Encryption key derived fresh from mnemonic via `getMnemonicByHash`
- Room names recovered from message content/subject tags for groups with placeholder names

**Server-backed block list:**
- Blocked contacts/groups stored server-side, cached locally on init via `fetchBlocks`
- Block/unblock actions sync to server

**Touch endpoint for last_message_timestamp:**
- `touchRoom` POSTs to `/api/nostr/rooms/<room_id>/touch/` after messages arrive (debounced per room, 2s cooldown)
- Triggers debounced `fetchRooms` so ordering updates from server

**Other improvements:**
- `deletedRooms` simplified to a string array of room IDs
- Persistence no longer stores rooms/blocks (server is source of truth)
- Components use server-backed actions (`archiveRoom`, `deleteRoom`, `blockContact`, etc.) instead of direct commits
- `fetchRooms` maps snake_case server fields to camelCase local fields
- `apiDelete` sends `wallet_hash` in body instead of query string
- `receiveMessage` guards against missing wallet keys
- Last-active poll interval changed from 2 min to 1 min
- Show Active Status toggle syncs to server via `/api/nostr/active-status/`
- `ensureSubscribed` returns promise chain (fixes blank messages bug)

### Backend endpoints required

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/api/nostr/rooms/?wallet_hash=` | GET | Fetch rooms |
| `/api/nostr/rooms/` | POST | Upsert room |
| `/api/nostr/rooms/<room_id>/` | PATCH | Update room |
| `/api/nostr/rooms/<room_id>/` | DELETE | Remove room |
| `/api/nostr/rooms/<room_id>/touch/` | POST | Update last_message_timestamp |
| `/api/nostr/blocks/?wallet_hash=` | GET | Fetch blocks |
| `/api/nostr/blocks/contacts/` | POST | Block contact |
| `/api/nostr/blocks/contacts/<pub_key>/` | DELETE | Unblock contact |
| `/api/nostr/blocks/groups/` | POST | Block group |
| `/api/nostr/blocks/groups/<room_id>/` | DELETE | Unblock group |
| `/api/nostr/active-status/` | POST | Set show_active_status |