### PR TITLE
Fix chat profile horizontal overflow on Android

### DIFF
--- a/src/pages/apps/chat/profile.vue
+++ b/src/pages/apps/chat/profile.vue
@@ -888,10 +888,19 @@ export default {
 </script>
 
 <style scoped>
+#app-container {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+}
+
 .profile-body {
   padding: 16px;
   max-width: 600px;
   margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 /* Identity card */
@@ -958,6 +967,8 @@ export default {
   margin: -4px -8px;
   border-radius: 6px;
   transition: background 0.15s ease;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .identity-npub:hover {
@@ -968,6 +979,10 @@ export default {
   font-family: 'Courier New', monospace;
   font-size: 13px;
   color: #6b7280;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .copy-icon {
@@ -1017,6 +1032,12 @@ export default {
   gap: 12px;
 }
 
+@media (max-width: 480px) {
+  .setting-row {
+    flex-wrap: wrap;
+  }
+}
+
 .setting-content {
   flex: 1;
   min-width: 0;
@@ -1045,6 +1066,12 @@ export default {
 .setting-input {
   width: 100%;
   max-width: 280px;
+}
+
+@media (max-width: 480px) {
+  .setting-input {
+    max-width: 100%;
+  }
 }
 
 .setting-input :deep(.q-field__control) {


### PR DESCRIPTION
## Summary

The chat profile page (`/apps/chat/profile`) required sideward scrolling on Android — divs extended beyond the screen width. The chat index and conversation pages fit the screen correctly.

## Root cause

The chat index page (`src/pages/apps/chat/index.vue:1161`) and conversation page (`src/pages/apps/chat/conversation.vue:2052`) both override `#app-container` with `display: flex; flex-direction: column`, but the profile page did not. Without this, `#app-container` was a regular block element, allowing children to push beyond the viewport without being constrained by the flex layout algorithm.

## Changes

- **Override `#app-container`** with `display: flex; flex-direction: column; overflow-x: hidden` to match the chat index and conversation pages
- **Constrain `identity-npub`** with `max-width: 100%; overflow: hidden` and add `min-width: 0` to `npub-text` so `text-overflow: ellipsis` works correctly inside the inline-flex layout
- **Make `setting-input` responsive** (`max-width: 100%` under 480px) and allow `setting-row` to wrap so action buttons drop below on narrow screens
- **Add `overflow-x: hidden`** to `profile-body` as a safety measure

## Testing

- Verified on Android (narrow viewport) that the page no longer requires horizontal scrolling
- Layout matches the chat index page behavior