### PR TITLE
Fix RFP page hang when navigating from rewards home for new users

### DIFF
--- a/src/pages/apps/rewards/rfp.vue
+++ b/src/pages/apps/rewards/rfp.vue
@@ -418,32 +418,39 @@ export default {
       }
 
       // fetch and load data
-      let rpData = null
-      if (this.rpId === -1) {
-        // open help dialog
-        this.isHelpActive = true
+      try {
+        let rpData = null
+        if (this.rpId === -1) {
+          // open help dialog
+          this.isHelpActive = true
 
-        // new user; create and update necessary data
-        rpData = await createRfPromoData()
-        this.rpId = rpData.id
-        await this.$router.replace({ params: { id: String(rpData.id) } })
-        rpData = await updateRfPromoData(rpData.id, {
-          contract_ct_address: this.rpContract.contract.tokenAddress
-        })
-        updateUserPromoData({ rp: rpData.id })
-      } else {
-        rpData = await getRfPromoData(this.rpId)
-      }
+          // new user; create and update necessary data
+          rpData = await createRfPromoData()
+          if (!rpData) throw new Error('Failed to create RFP promo data')
 
-      if (rpData && Object.keys(rpData).length > 0) {
-        this.rpMax = await getRpMaxRedeemable()
-        this.redeemedPoints = rpData.redeemed_points
-        this.referralCode = rpData.referral_code
-        this.referralsList = (rpData.rp_referrals || []).sort((a, b) => {
-          return new Date(b.date_created) - new Date(a.date_created)
-        })
-        this.referralsOverallStats = rpData.rp_referrals_overall_stats
-      } else {
+          this.rpId = rpData.id
+          await this.$router.replace({ params: { id: String(rpData.id) } })
+          rpData = await updateRfPromoData(this.rpId, {
+            contract_ct_address: this.rpContract.contract.tokenAddress
+          })
+          updateUserPromoData({ rp: this.rpId })
+        } else {
+          rpData = await getRfPromoData(this.rpId)
+        }
+
+        if (rpData && Object.keys(rpData).length > 0) {
+          this.rpMax = await getRpMaxRedeemable()
+          this.redeemedPoints = rpData.redeemed_points
+          this.referralCode = rpData.referral_code
+          this.referralsList = (rpData.rp_referrals || []).sort((a, b) => {
+            return new Date(b.date_created) - new Date(a.date_created)
+          })
+          this.referralsOverallStats = rpData.rp_referrals_overall_stats
+        } else {
+          this.dataError = this.$t('DataLoadError')
+        }
+      } catch (error) {
+        console.error(error)
         this.dataError = this.$t('DataLoadError')
       }
 

--- a/src/utils/engagementhub-utils/rewards.js
+++ b/src/utils/engagementhub-utils/rewards.js
@@ -190,7 +190,7 @@ export async function updateUserRewardsData(id, data) {
 }
 
 export async function updateRfPromoData (id, data) {
-  await updateData(`rfpromo/${id}/`, data)
+  return await updateData(`rfpromo/${id}/`, data)
 }
 
 // ========== other functions ==========


### PR DESCRIPTION
## Root Cause

When a user without existing RFP promo data clicks the Refer-a-Friend button on the rewards home page, `promo.id` is `null`, so they navigate to `/rfp/-1`. In `loadData()`, the `rpId === -1` branch runs and:

1. `createRfPromoData()` succeeds → `rpData = { id: 43, ... }`
2. `router.replace()` changes URL to `/rfp/43` (triggers `requestManager.abortAll()` in the router guard — a second abort)
3. `rpData = await updateRfPromoData(...)` → **`updateRfPromoData` had no `return` statement**, so `rpData` became `undefined`
4. `updateUserPromoData({ rp: rpData.id })` → **TypeError** (cannot read `.id` of `undefined`)
5. This error was **uncaught**, so `this.isLoading = false` never executed → **skeletons forever**

On hard reload, the URL is already `/rfp/43` (from step 2's `router.replace`), so the `else` branch runs `getRfPromoData(43)` which works fine — explaining why reload "fixes" it.

## Fixes

1. **`src/utils/engagementhub-utils/rewards.js`** — Added `return` to `updateRfPromoData` so it returns the PATCH response data (matching the pattern of `updateUserRewardsData`).

2. **`src/pages/apps/rewards/rfp.vue`** — Wrapped the data-fetching section in `loadData()` in a try-catch so any error sets `dataError` and always reaches `this.isLoading = false` (prevents the hang). Also changed `rpData.id` → `this.rpId` in the `updateUserPromoData` call as a defensive measure, and added a null check on `createRfPromoData()` result.

## Testing

- Navigate from rewards home → Refer-a-Friend promo button with no existing RFP data: page should load content (no perpetual skeletons).
- Hard reload on `/rfp/:id`: still works as before.
- Error states (network failure during create/update) now show the error card with retry instead of hanging.