### PR TITLE
fix: wallet import failure

### DIFF
--- a/src/pages/registration/accounts.vue
+++ b/src/pages/registration/accounts.vue
@@ -1840,15 +1840,18 @@ export default {
       }
     },
     goToStep4 () {
-      // Handle restore flow navigation
-      if (this.importSeedPhrase && this.restoreStep === 4) {
-        this.$router.push('/accounts/restore/step-5')
+      if (this.importSeedPhrase) {
+        this.$router.push('/accounts/restore/step-4')
       } else {
         this.$router.push('/accounts/create/step-5')
       }
     },
     goToStep5 () {
-      this.$router.push('/accounts/create/step-6')
+      if (this.importSeedPhrase) {
+        this.$router.push('/accounts/restore/step-5')
+      } else {
+        this.$router.push('/accounts/create/step-6')
+      }
     },
 
     setupSecurity (authType) {

--- a/src/store/nostr-chat/actions.js
+++ b/src/store/nostr-chat/actions.js
@@ -358,7 +358,7 @@ export async function fetchOwnProfile ({ commit, dispatch }, pubKeyHex) {
 
 export async function registerNostrPubkey ({ state, rootGetters }) {
   const ws = getWalletState(state)
-  if (!ws.keys.pubKeyHex) {
+  if (!ws.keys?.pubKeyHex) {
     debug('Skip pubkey registration: no pubkey')
     return
   }

--- a/src/utils/subscription-utils.js
+++ b/src/utils/subscription-utils.js
@@ -54,6 +54,9 @@ export async function checkLiftTokenBalance () {
         if (error?.response?.status === 404 || error?.message?.includes('404')) {
           return 0
         }
+        if (error?.code === 'ECONNABORTED') {
+          return 0
+        }
         console.debug(`LIFT token balance check failed for wallet ${walletHash}:`, error)
         return 0
       }
@@ -67,7 +70,9 @@ export async function checkLiftTokenBalance () {
     
     return totalBalance
   } catch (error) {
-    console.error('Error checking total LIFT token balance:', error)
+    if (error?.code !== 'ECONNABORTED') {
+      console.error('Error checking total LIFT token balance:', error)
+    }
     return 0
   }
 }


### PR DESCRIPTION
Fixes three issues during wallet import/restore:

1. **Nostr pubkey crash** — `registerNostrPubkey` in `nostr-chat/actions.js` accessed `ws.keys.pubKeyHex` without optional chaining, throwing `TypeError` when wallet state was not initialized yet.

2. **Blank page after step-3** — `goToStep4` and `goToStep5` in `accounts.vue` navigated to create-flow routes instead of restore-flow routes, causing a blank page since those templates do not render when `importSeedPhrase` is true.

3. **Noisy ECONNABORTED logs** — LIFT token balance checks logged "Request aborted" errors during route navigation (caused by `requestManager.abortAll()` patching global XHR). Now silently returns 0.