### PR TITLE
Improve Apps Page: Payment Hub updates, Pinned Apps drag-to-reorder, and long-press UX

### DIFF
--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -171,7 +171,7 @@
           >
             <div class="relative-position" style="display: inline-block;">
               <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
-                <span draggable="false"><q-icon size="30px" color="white" :name="app.iconName" /></span>
+                <q-icon size="30px" color="white" :name="app.iconName" />
               </div>
               <span v-if="app.beta" class="app-beta-pill-grid">BETA</span>
               <div
@@ -182,7 +182,6 @@
               </div>
             </div>
             <p
-              draggable="false"
               class="app-grid-name pt-label"
               :class="[getDarkModeClass(darkMode), !app.active ? 'text-grey' : '']"
             >
@@ -1379,6 +1378,7 @@ export default {
     &[draggable="true"] {
       cursor: grab;
       &:active { cursor: grabbing; }
+      img, i, span { -webkit-user-drag: none; user-drag: none; }
     }
     &.drag-over {
       .app-grid-tile {

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -170,8 +170,8 @@
             @dragend="cat.isPinned && dragSupported && onDragEnd(app)"
           >
             <div class="relative-position" style="display: inline-block;">
-              <div class="app-grid-tile bg-grad" draggable="false" :class="{ 'tile-inactive': !app.active }">
-                <q-icon size="30px" color="white" draggable="false" :name="app.iconName" />
+              <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
+                <span draggable="false"><q-icon size="30px" color="white" :name="app.iconName" /></span>
               </div>
               <span v-if="app.beta" class="app-beta-pill-grid">BETA</span>
               <div

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -77,6 +77,17 @@
           <span class="section-title">{{ cat.label }}</span>
         </div>
 
+        <div
+          v-if="cat.isPinned && draggedAppId && dragSupported"
+          class="unpin-bin"
+          :class="getDarkModeClass(darkMode)"
+          @dragover.prevent
+          @drop="onUnpinDrop"
+        >
+          <q-icon name="mdi-pin-off" size="20px" />
+          <span>{{ $t('DropToUnpin', {}, 'Drop here to unpin') }}</span>
+        </div>
+
         <div class="section-divider" :class="getDarkModeClass(darkMode)"></div>
 
         <!-- List view -->
@@ -772,9 +783,13 @@ export default {
       this.draggedAppId = null
       this.dragOverAppId = null
     },
-    onDragEnd (app) {
+    onDragEnd () {
+      this.draggedAppId = null
+      this.dragOverAppId = null
+    },
+    onUnpinDrop () {
       if (this.draggedAppId) {
-        this.togglePin(app.id)
+        this.togglePin(this.draggedAppId)
       }
       this.draggedAppId = null
       this.dragOverAppId = null
@@ -1140,6 +1155,30 @@ export default {
   .section-pin-icon {
     &.dark { color: rgba(59, 123, 246, 0.7); }
     &.light { color: rgba(59, 123, 246, 0.6); }
+  }
+  .unpin-bin {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: 0 14px 8px;
+    padding: 12px;
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 500;
+    transition: background 0.15s ease, border-color 0.15s ease;
+    &.dark {
+      background: rgba(239, 83, 80, 0.08);
+      border: 2px dashed rgba(239, 83, 80, 0.4);
+      color: rgba(239, 83, 80, 0.7);
+      &:hover { background: rgba(239, 83, 80, 0.15); border-color: rgba(239, 83, 80, 0.6); }
+    }
+    &.light {
+      background: rgba(239, 83, 80, 0.06);
+      border: 2px dashed rgba(239, 83, 80, 0.3);
+      color: rgba(239, 83, 80, 0.65);
+      &:hover { background: rgba(239, 83, 80, 0.12); border-color: rgba(239, 83, 80, 0.5); }
+    }
   }
   .pin-indicator {
     &.dark { color: rgba(59, 123, 246, 0.6); }

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -77,16 +77,6 @@
           <span class="section-title">{{ cat.label }}</span>
         </div>
 
-        <div
-          class="unpin-bin"
-          :class="[getDarkModeClass(darkMode), { 'unpin-bin-visible': cat.isPinned && draggedAppId && dragSupported }]"
-          @dragover.prevent
-          @drop="onUnpinDrop"
-        >
-          <q-icon name="mdi-pin-off" size="20px" />
-          <span>{{ $t('DropToUnpin', {}, 'Drop here to unpin') }}</span>
-        </div>
-
         <div class="section-divider" :class="getDarkModeClass(darkMode)"></div>
 
         <!-- List view -->
@@ -94,6 +84,7 @@
           <div
             v-for="(app, index) in cat.apps"
             :key="app.id || index"
+            :data-app-id="app.id"
             class="app-row"
             :class="[
               getDarkModeClass(darkMode),
@@ -108,12 +99,10 @@
           >
             <div
               v-if="cat.isPinned"
-              :draggable="dragSupported ? 'true' : false"
               class="app-drag-handle"
               :class="getDarkModeClass(darkMode)"
-              @dragstart="onDragStart(app, $event)"
-              @touchstart.stop
-              @mousedown.stop
+              @mousedown="onHandleDragStart(app, $event, 'mouse')"
+              @touchstart="onHandleDragStart(app, $event, 'touch')"
             >
               <q-icon name="drag_indicator" size="20px" />
             </div>
@@ -169,25 +158,37 @@
             @drop="cat.isPinned && dragSupported && onDrop(app, $event)"
             @dragend="cat.isPinned && dragSupported && onDragEnd()"
           >
-            <div class="relative-position" style="display: inline-block;">
+            <div class="relative-position" draggable="false" style="display: inline-block;">
               <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
-                <q-icon size="30px" color="white" :name="app.iconName" />
+                <q-icon size="30px" color="white" :name="app.iconName" draggable="false" />
               </div>
-              <span v-if="app.beta" class="app-beta-pill-grid">BETA</span>
+              <span v-if="app.beta" class="app-beta-pill-grid" draggable="false">BETA</span>
               <div
                 v-if="app.id === 'chat' && chatUnreadCount > 0"
                 class="app-unread-badge"
+                draggable="false"
               >
                 {{ chatUnreadCountLabel }}
               </div>
             </div>
             <p
+              draggable="false"
               class="app-grid-name pt-label"
               :class="[getDarkModeClass(darkMode), !app.active ? 'text-grey' : '']"
             >
               {{ app.name }}
             </p>
           </div>
+        </div>
+
+        <div
+          class="unpin-bin"
+          :class="[getDarkModeClass(darkMode), { 'unpin-bin-visible': cat.isPinned && draggedAppId && dragSupported }]"
+          @dragover.prevent
+          @drop="onUnpinDrop"
+        >
+          <q-icon name="mdi-pin-off" size="20px" />
+          <span>{{ $t('DropToUnpin', {}, 'Drop here to unpin') }}</span>
         </div>
       </section>
 
@@ -741,6 +742,41 @@ export default {
       }
       localStorage.setItem('pinnedAppIds', JSON.stringify(this.pinnedAppIds))
     },
+    onHandleDragStart (app, event, source) {
+      event.preventDefault()
+      this.draggedAppId = app.id
+      const getPos = (e) => source === 'mouse'
+        ? { x: e.clientX, y: e.clientY }
+        : { x: e.touches[0].clientX, y: e.touches[0].clientY }
+      let pos = getPos(event)
+      const onMove = (e) => {
+        e.preventDefault()
+        pos = getPos(e)
+        const el = document.elementFromPoint(pos.x, pos.y)
+        const row = el && el.closest('[data-app-id]')
+        if (row) {
+          const id = row.getAttribute('data-app-id')
+          this.dragOverAppId = id !== this.draggedAppId ? id : null
+        } else {
+          this.dragOverAppId = null
+        }
+      }
+      const onEnd = () => {
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onEnd)
+        document.removeEventListener('touchmove', onMove)
+        document.removeEventListener('touchend', onEnd)
+        if (this.draggedAppId && this.dragOverAppId) {
+          this.completeReorder(this.draggedAppId, this.dragOverAppId)
+        }
+        this.draggedAppId = null
+        this.dragOverAppId = null
+      }
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onEnd)
+      document.addEventListener('touchmove', onMove, { passive: false })
+      document.addEventListener('touchend', onEnd)
+    },
     onDragStart (app, event) {
       this.draggedAppId = app.id
       event.dataTransfer.effectAllowed = 'move'
@@ -777,6 +813,16 @@ export default {
       localStorage.setItem('pinnedAppIds', JSON.stringify(ids))
       this.draggedAppId = null
       this.dragOverAppId = null
+    },
+    completeReorder (fromId, toId) {
+      const ids = [...this.pinnedAppIds]
+      const fromIndex = ids.indexOf(fromId)
+      const toIndex = ids.indexOf(toId)
+      if (fromIndex === -1 || toIndex === -1) return
+      ids.splice(fromIndex, 1)
+      ids.splice(toIndex, 0, fromId)
+      this.pinnedAppIds = ids
+      localStorage.setItem('pinnedAppIds', JSON.stringify(ids))
     },
     onDragEnd () {
       this.draggedAppId = null

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -170,8 +170,8 @@
             @dragend="cat.isPinned && dragSupported && onDragEnd(app)"
           >
             <div class="relative-position" style="display: inline-block;">
-              <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
-                <q-icon size="30px" color="white" :name="app.iconName" />
+              <div class="app-grid-tile bg-grad" draggable="false" :class="{ 'tile-inactive': !app.active }">
+                <q-icon size="30px" color="white" draggable="false" :name="app.iconName" />
               </div>
               <span v-if="app.beta" class="app-beta-pill-grid">BETA</span>
               <div
@@ -182,6 +182,7 @@
               </div>
             </div>
             <p
+              draggable="false"
               class="app-grid-name pt-label"
               :class="[getDarkModeClass(darkMode), !app.active ? 'text-grey' : '']"
             >

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -730,10 +730,6 @@ export default {
         this.$router.push(app.path)
       }
     },
-    onLongPressApp(event, app) {
-      event.preventDefault()
-      app?.onLongPress?.(event)
-    },
     isPinned (appId) {
       return this.pinnedAppIds.includes(appId)
     },
@@ -795,6 +791,10 @@ export default {
     },
     showAppContextMenu (app, event) {
       if (!app.active) return
+      if (app.onLongPress) {
+        app.onLongPress(event)
+        return
+      }
       const pinned = this.isPinned(app.id)
       this.$q.bottomSheet({
         class: `text-bow ${this.getDarkModeClass(this.darkMode)}`,

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -86,11 +86,22 @@
             class="app-row"
             :class="[
               getDarkModeClass(darkMode),
-              { 'app-inactive': !app.active, 'app-beta-row': cat.isBeta, 'app-pinned-row': cat.isPinned }
+              { 'app-inactive': !app.active, 'app-beta-row': cat.isBeta, 'app-pinned-row': cat.isPinned, 'drag-over': cat.isPinned && dragOverAppId === app.id }
             ]"
-            v-on-long-press="[(event) => showAppContextMenu(app, event)]"
             @click="openApp(app)"
+            v-on-long-press="[(event) => showAppContextMenu(app, event)]"
+            @dragover="cat.isPinned && onDragOver(app, $event)"
+            @dragleave="cat.isPinned && onDragLeave()"
+            @drop="cat.isPinned && onDrop(app, $event)"
           >
+            <div
+              v-if="cat.isPinned"
+              :draggable="'true'"
+              class="app-drag-handle"
+              @dragstart="onDragStart(app, $event)"
+            >
+              <q-icon name="drag_indicator" size="20px" />
+            </div>
             <div class="app-icon-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
               <q-icon size="26px" color="white" :name="app.iconName" />
             </div>
@@ -105,6 +116,14 @@
               <div v-if="app.id === 'chat' && chatUnreadCount > 0" class="app-unread-badge">
                 {{ chatUnreadCountLabel }}
               </div>
+              <q-icon
+                v-if="cat.isPinned"
+                name="mdi-pin-off"
+                size="18px"
+                class="app-unpin-icon"
+                :class="getDarkModeClass(darkMode)"
+                @click.stop="togglePin(app.id)"
+              />
               <q-icon
                 v-if="app.active"
                 name="chevron_right"
@@ -124,12 +143,30 @@
             class="app-grid-item"
             :class="[
               getDarkModeClass(darkMode),
-              { 'app-inactive': !app.active }
+              { 'app-inactive': !app.active, 'drag-over': cat.isPinned && dragOverAppId === app.id }
             ]"
-            v-on-long-press="[(event) => showAppContextMenu(app, event)]"
             @click="openApp(app)"
+            v-on-long-press="[(event) => showAppContextMenu(app, event)]"
+            @dragover="cat.isPinned && onDragOver(app, $event)"
+            @dragleave="cat.isPinned && onDragLeave()"
+            @drop="cat.isPinned && onDrop(app, $event)"
           >
             <div class="relative-position" style="display: inline-block;">
+              <div
+                v-if="cat.isPinned"
+                :draggable="'true'"
+                class="app-grid-drag-handle"
+                @dragstart="onDragStart(app, $event)"
+              >
+                <q-icon name="drag_indicator" size="16px" color="white" />
+              </div>
+              <div
+                v-if="cat.isPinned"
+                class="app-grid-unpin-btn"
+                @click.stop="togglePin(app.id)"
+              >
+                <q-icon name="mdi-pin-off" size="14px" color="white" />
+              </div>
               <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
                 <q-icon size="30px" color="white" :name="app.iconName" />
               </div>
@@ -161,7 +198,6 @@
 
 <script>
 import { Platform } from 'quasar';
-import { vOnLongPress } from '@vueuse/components'
 import { getDarkModeClass } from 'src/utils/theme-darkmode-utils'
 import MarketplaceAppSelectionDialog from 'src/components/marketplace/MarketplaceAppSelectionDialog.vue'
 import BetaAppDialog from 'src/components/apps/BetaAppDialog.vue'
@@ -177,7 +213,69 @@ export default {
     BetaAppDialog
   },
   directives: {
-    'on-long-press': vOnLongPress,
+    'on-long-press': {
+      mounted (el, binding) {
+        const handler = typeof binding.value === 'function'
+          ? binding.value
+          : Array.isArray(binding.value) ? binding.value[0] : null
+        if (!handler) return
+
+        let timer = null
+        let startX = 0
+        let startY = 0
+        let isPending = false
+
+        function start (x, y, e) {
+          startX = x
+          startY = y
+          isPending = true
+          timer = setTimeout(() => {
+            timer = null
+            isPending = false
+            handler(e)
+          }, 500)
+        }
+
+        function cancel () {
+          if (timer) {
+            clearTimeout(timer)
+            timer = null
+          }
+          isPending = false
+        }
+
+        function move (x, y) {
+          if (!isPending) return
+          const dx = Math.abs(x - startX)
+          const dy = Math.abs(y - startY)
+          if (dx > 10 || dy > 10) cancel()
+        }
+
+        el.addEventListener('touchstart', (e) => {
+          const t = e.touches[0]
+          start(t.clientX, t.clientY, e)
+        }, { passive: true })
+
+        el.addEventListener('touchmove', (e) => {
+          const t = e.touches[0]
+          move(t.clientX, t.clientY)
+        }, { passive: true })
+
+        el.addEventListener('touchend', cancel)
+        el.addEventListener('touchcancel', cancel)
+
+        el.addEventListener('mousedown', (e) => {
+          start(e.clientX, e.clientY, e)
+        })
+
+        el.addEventListener('mousemove', (e) => {
+          move(e.clientX, e.clientY)
+        })
+
+        el.addEventListener('mouseup', cancel)
+        el.addEventListener('mouseleave', cancel)
+      }
+    },
   },
   data () {
     return {
@@ -441,7 +539,9 @@ export default {
       rampAppSelection: false,
       disableRampSelection: false,
       activeCategory: null,
-      categoryObserver: null
+      categoryObserver: null,
+      draggedAppId: null,
+      dragOverAppId: null
     }
   },
   computed: {
@@ -494,7 +594,9 @@ export default {
       for (const cat of this.categoryDefinitions) {
         let apps
         if (cat.isPinned) {
-          apps = this.filteredApps.filter(app => this.pinnedAppIds.includes(app.id))
+          apps = this.filteredApps
+            .filter(app => this.pinnedAppIds.includes(app.id))
+            .sort((a, b) => this.pinnedAppIds.indexOf(a.id) - this.pinnedAppIds.indexOf(b.id))
         } else {
           apps = this.filteredApps.filter(app => app.category === cat.id)
         }
@@ -598,15 +700,52 @@ export default {
       }
       localStorage.setItem('pinnedAppIds', JSON.stringify(this.pinnedAppIds))
     },
+    onDragStart (app, event) {
+      this.draggedAppId = app.id
+      event.dataTransfer.effectAllowed = 'move'
+      event.dataTransfer.setData('text/plain', app.id)
+    },
+    onDragOver (app, event) {
+      if (!this.draggedAppId || this.draggedAppId === app.id) return
+      event.preventDefault()
+      this.dragOverAppId = app.id
+    },
+    onDragLeave () {
+      this.dragOverAppId = null
+    },
+    onDrop (app, event) {
+      event.preventDefault()
+      const fromId = this.draggedAppId
+      const toId = app.id
+      if (!fromId || !toId || fromId === toId) {
+        this.draggedAppId = null
+        this.dragOverAppId = null
+        return
+      }
+      const ids = [...this.pinnedAppIds]
+      const fromIndex = ids.indexOf(fromId)
+      const toIndex = ids.indexOf(toId)
+      if (fromIndex === -1 || toIndex === -1) {
+        this.draggedAppId = null
+        this.dragOverAppId = null
+        return
+      }
+      ids.splice(fromIndex, 1)
+      ids.splice(toIndex, 0, fromId)
+      this.pinnedAppIds = ids
+      localStorage.setItem('pinnedAppIds', JSON.stringify(ids))
+      this.draggedAppId = null
+      this.dragOverAppId = null
+    },
     showAppContextMenu (app, event) {
       if (!app.active) return
-      const pinned = this.isPinned(app.id)
+      if (this.isPinned(app.id)) return
       this.$q.bottomSheet({
         class: `text-bow ${this.getDarkModeClass(this.darkMode)}`,
         actions: [
           {
-            label: pinned ? this.$t('Unpin', {}, 'Unpin') : this.$t('Pin', {}, 'Pin'),
-            icon: pinned ? ' mdi-pin-off' : 'mdi-pin',
+            label: this.$t('Pin', {}, 'Pin'),
+            icon: 'mdi-pin',
             id: 'pin',
             color: this.themeColor,
           },
@@ -1029,6 +1168,36 @@ export default {
       cursor: default;
       .app-name, .app-desc { opacity: 0.35; }
     }
+    &.drag-over {
+      background: rgba(59, 123, 246, 0.12) !important;
+      outline: 2px dashed rgba(59, 123, 246, 0.5);
+      outline-offset: -2px;
+    }
+  }
+
+  .app-drag-handle {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 48px;
+    cursor: grab;
+    color: rgba(255,255,255,0.4);
+    transition: color 0.15s ease;
+    -webkit-user-select: none;
+    user-select: none;
+    &:active { cursor: grabbing; }
+    &:hover { color: rgba(255,255,255,0.8); }
+    .light & { color: rgba(0,0,0,0.25); }
+    .light &:hover { color: rgba(0,0,0,0.6); }
+  }
+
+  .app-unpin-icon {
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.15s ease;
+    &:hover { opacity: 1; }
   }
 
   .app-icon-tile {
@@ -1121,6 +1290,49 @@ export default {
       max-width: calc(16.666% - 4px);
     }
     &.app-inactive { cursor: default; }
+    &.drag-over {
+      .app-grid-tile {
+        outline: 3px solid rgba(59, 123, 246, 0.6);
+        outline-offset: 3px;
+      }
+    }
+  }
+  .app-grid-drag-handle {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    z-index: 12;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: grab;
+    -webkit-user-select: none;
+    user-select: none;
+    &:active { cursor: grabbing; }
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    .app-grid-item:hover & { opacity: 1; }
+  }
+  .app-grid-unpin-btn {
+    position: absolute;
+    top: -4px;
+    left: -4px;
+    z-index: 12;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    .app-grid-item:hover & { opacity: 1; }
   }
   .app-grid-tile {
     width: 56px;

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -100,6 +100,7 @@
               v-if="cat.isPinned"
               :draggable="dragSupported ? 'true' : false"
               class="app-drag-handle"
+              :class="getDarkModeClass(darkMode)"
               @dragstart="onDragStart(app, $event)"
               @touchstart.stop
               @mousedown.stop
@@ -218,9 +219,11 @@ export default {
         let isPending = false
         let longPressTriggered = false
         let activeSource = null
+        let lastLongPressTime = 0
 
         function start (x, y, e, source) {
           if (activeSource && activeSource !== source) return
+          if (Date.now() - lastLongPressTime < 100) return
           startX = x
           startY = y
           isPending = true
@@ -230,6 +233,7 @@ export default {
             timer = null
             isPending = false
             longPressTriggered = true
+            lastLongPressTime = Date.now()
             handler(e)
           }, 500)
         }
@@ -255,6 +259,7 @@ export default {
             e.preventDefault()
             e.stopPropagation()
             longPressTriggered = false
+            lastLongPressTime = 0
           }
         }
 
@@ -1220,14 +1225,18 @@ export default {
     width: 28px;
     height: 48px;
     cursor: grab;
-    color: rgba(255,255,255,0.4);
     transition: color 0.15s ease;
     -webkit-user-select: none;
     user-select: none;
     &:active { cursor: grabbing; }
-    &:hover { color: rgba(255,255,255,0.8); }
-    .light & { color: rgba(0,0,0,0.25); }
-    .light &:hover { color: rgba(0,0,0,0.6); }
+    &.dark {
+      color: rgba(255,255,255,0.4);
+      &:hover { color: rgba(255,255,255,0.8); }
+    }
+    &.light {
+      color: rgba(0,0,0,0.25);
+      &:hover { color: rgba(0,0,0,0.6); }
+    }
   }
 
   .app-unpin-icon {

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -385,12 +385,12 @@ export default {
           id: 'payment-hub',
           name: this.$t('PaymentHub', {}, 'Payment Hub'),
           description: this.$t('Apps.PaymentHub.Description', {}, 'Manage Payment Hub Stores, API Keys, and Invoices.'),
-          iconName: 'img:paytaca_payment_hub_logo_bg.png',
+          iconName: 'hub',
           path: '/apps/payment-hub/',
           iconStyle: 'width: 100%; height: 100%;',
           active: true,
-          beta: true,
-          category: 'payment-hub'
+          beta: false,
+          category: 'marketplace'
         },
         ...(DISPLAY_SUBS_APP ? [{
           id: 'payment-hub-subscriptions',

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -60,6 +60,7 @@
     </div>
     <div class="apps-hint-text q-px-md q-mt-xs" :class="getDarkModeClass(darkMode)">
       {{ $t('LongPressToPin', {}, 'Long press on the app to pin or unpin.') }}
+      <template v-if="dragSupported">{{ $t('DragToReorder', {}, 'Drag pinned apps to reorder.') }}</template>
     </div>
 
     <div id="apps" ref="apps" class="apps-list-container" :class="[getDarkModeClass(darkMode), `view-${viewMode}`]">
@@ -86,18 +87,18 @@
             class="app-row"
             :class="[
               getDarkModeClass(darkMode),
-              { 'app-inactive': !app.active, 'app-beta-row': cat.isBeta, 'app-pinned-row': cat.isPinned, 'drag-over': cat.isPinned && dragOverAppId === app.id }
+              { 'app-inactive': !app.active, 'app-beta-row': cat.isBeta, 'app-pinned-row': cat.isPinned, 'drag-over': cat.isPinned && dragSupported && dragOverAppId === app.id }
             ]"
             @click="openApp(app)"
             v-on-long-press="[(event) => showAppContextMenu(app, event)]"
-            @dragover="cat.isPinned && onDragOver(app, $event)"
-            @dragleave="cat.isPinned && onDragLeave()"
-            @drop="cat.isPinned && onDrop(app, $event)"
-            @dragend="cat.isPinned && onDragEnd(app)"
+            @dragover="cat.isPinned && dragSupported && onDragOver(app, $event)"
+            @dragleave="cat.isPinned && dragSupported && onDragLeave()"
+            @drop="cat.isPinned && dragSupported && onDrop(app, $event)"
+            @dragend="cat.isPinned && dragSupported && onDragEnd(app)"
           >
             <div
               v-if="cat.isPinned"
-              :draggable="'true'"
+              :draggable="dragSupported ? 'true' : false"
               class="app-drag-handle"
               @dragstart="onDragStart(app, $event)"
               @touchstart.stop
@@ -143,19 +144,19 @@
           <div
             v-for="(app, index) in cat.apps"
             :key="app.id || index"
-            :draggable="cat.isPinned ? 'true' : false"
+            :draggable="(cat.isPinned && dragSupported) ? 'true' : false"
             class="app-grid-item"
             :class="[
               getDarkModeClass(darkMode),
-              { 'app-inactive': !app.active, 'drag-over': cat.isPinned && dragOverAppId === app.id }
+              { 'app-inactive': !app.active, 'drag-over': cat.isPinned && dragSupported && dragOverAppId === app.id }
             ]"
             @click="openApp(app)"
             v-on-long-press="[(event) => showAppContextMenu(app, event)]"
-            @dragstart="cat.isPinned && onDragStart(app, $event)"
-            @dragover="cat.isPinned && onDragOver(app, $event)"
-            @dragleave="cat.isPinned && onDragLeave()"
-            @drop="cat.isPinned && onDrop(app, $event)"
-            @dragend="cat.isPinned && onDragEnd(app)"
+            @dragstart="cat.isPinned && dragSupported && onDragStart(app, $event)"
+            @dragover="cat.isPinned && dragSupported && onDragOver(app, $event)"
+            @dragleave="cat.isPinned && dragSupported && onDragLeave()"
+            @drop="cat.isPinned && dragSupported && onDrop(app, $event)"
+            @dragend="cat.isPinned && dragSupported && onDragEnd(app)"
           >
             <div class="relative-position" style="display: inline-block;">
               <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
@@ -215,14 +216,20 @@ export default {
         let startX = 0
         let startY = 0
         let isPending = false
+        let longPressTriggered = false
+        let activeSource = null
 
-        function start (x, y, e) {
+        function start (x, y, e, source) {
+          if (activeSource && activeSource !== source) return
           startX = x
           startY = y
           isPending = true
+          longPressTriggered = false
+          activeSource = source
           timer = setTimeout(() => {
             timer = null
             isPending = false
+            longPressTriggered = true
             handler(e)
           }, 500)
         }
@@ -233,6 +240,7 @@ export default {
             timer = null
           }
           isPending = false
+          activeSource = null
         }
 
         function move (x, y) {
@@ -242,29 +250,57 @@ export default {
           if (dx > 10 || dy > 10) cancel()
         }
 
-        el.addEventListener('touchstart', (e) => {
-          const t = e.touches[0]
-          start(t.clientX, t.clientY, e)
-        }, { passive: true })
+        function suppressClick (e) {
+          if (longPressTriggered) {
+            e.preventDefault()
+            e.stopPropagation()
+            longPressTriggered = false
+          }
+        }
 
-        el.addEventListener('touchmove', (e) => {
+        function onTouchStart (e) {
+          const t = e.touches[0]
+          start(t.clientX, t.clientY, e, 'touch')
+        }
+
+        function onTouchMove (e) {
           const t = e.touches[0]
           move(t.clientX, t.clientY)
-        }, { passive: true })
+        }
 
+        function onMouseDown (e) {
+          start(e.clientX, e.clientY, e, 'mouse')
+        }
+
+        function onMouseMove (e) {
+          move(e.clientX, e.clientY)
+        }
+
+        el.addEventListener('touchstart', onTouchStart, { passive: true })
+        el.addEventListener('touchmove', onTouchMove, { passive: true })
         el.addEventListener('touchend', cancel)
         el.addEventListener('touchcancel', cancel)
-
-        el.addEventListener('mousedown', (e) => {
-          start(e.clientX, e.clientY, e)
-        })
-
-        el.addEventListener('mousemove', (e) => {
-          move(e.clientX, e.clientY)
-        })
-
+        el.addEventListener('mousedown', onMouseDown)
+        el.addEventListener('mousemove', onMouseMove)
         el.addEventListener('mouseup', cancel)
         el.addEventListener('mouseleave', cancel)
+        el.addEventListener('click', suppressClick, true)
+
+        el._longPressCleanup = () => {
+          cancel()
+          el.removeEventListener('touchstart', onTouchStart)
+          el.removeEventListener('touchmove', onTouchMove)
+          el.removeEventListener('touchend', cancel)
+          el.removeEventListener('touchcancel', cancel)
+          el.removeEventListener('mousedown', onMouseDown)
+          el.removeEventListener('mousemove', onMouseMove)
+          el.removeEventListener('mouseup', cancel)
+          el.removeEventListener('mouseleave', cancel)
+          el.removeEventListener('click', suppressClick, true)
+        }
+      },
+      unmounted (el) {
+        el._longPressCleanup?.()
       }
     },
   },
@@ -541,6 +577,9 @@ export default {
     },
     isNativeIOS () {
       return isNativeIOS()
+    },
+    dragSupported () {
+      return !Platform.is.mobile && !Platform.is.nativeMobile
     },
     theme () {
       return this.$store.getters['global/theme']

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -151,7 +151,7 @@
               { 'app-inactive': !app.active, 'drag-over': cat.isPinned && dragSupported && dragOverAppId === app.id }
             ]"
             @click="openApp(app)"
-            v-on-long-press="[(event) => showAppContextMenu(app, event)]"
+            v-on-long-press="!cat.isPinned ? [(event) => showAppContextMenu(app, event)] : undefined"
             @dragstart="cat.isPinned && dragSupported && onDragStart(app, $event)"
             @dragover="cat.isPinned && dragSupported && onDragOver(app, $event)"
             @dragleave="cat.isPinned && dragSupported && onDragLeave()"

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -98,11 +98,11 @@
             @dragend="cat.isPinned && dragSupported && onDragEnd()"
           >
             <div
-              v-if="cat.isPinned"
+              v-if="cat.isPinned && dragSupported"
               class="app-drag-handle"
               :class="getDarkModeClass(darkMode)"
-              @mousedown="onHandleDragStart(app, $event, 'mouse')"
-              @touchstart="onHandleDragStart(app, $event, 'touch')"
+              @mousedown.stop="onHandleDragStart(app, $event, 'mouse')"
+              @touchstart.stop="onHandleDragStart(app, $event, 'touch')"
             >
               <q-icon name="drag_indicator" size="20px" />
             </div>

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -93,12 +93,15 @@
             @dragover="cat.isPinned && onDragOver(app, $event)"
             @dragleave="cat.isPinned && onDragLeave()"
             @drop="cat.isPinned && onDrop(app, $event)"
+            @dragend="cat.isPinned && onDragEnd(app)"
           >
             <div
               v-if="cat.isPinned"
               :draggable="'true'"
               class="app-drag-handle"
               @dragstart="onDragStart(app, $event)"
+              @touchstart.stop
+              @mousedown.stop
             >
               <q-icon name="drag_indicator" size="20px" />
             </div>
@@ -140,6 +143,7 @@
           <div
             v-for="(app, index) in cat.apps"
             :key="app.id || index"
+            :draggable="cat.isPinned ? 'true' : false"
             class="app-grid-item"
             :class="[
               getDarkModeClass(darkMode),
@@ -147,26 +151,13 @@
             ]"
             @click="openApp(app)"
             v-on-long-press="[(event) => showAppContextMenu(app, event)]"
+            @dragstart="cat.isPinned && onDragStart(app, $event)"
             @dragover="cat.isPinned && onDragOver(app, $event)"
             @dragleave="cat.isPinned && onDragLeave()"
             @drop="cat.isPinned && onDrop(app, $event)"
+            @dragend="cat.isPinned && onDragEnd(app)"
           >
             <div class="relative-position" style="display: inline-block;">
-              <div
-                v-if="cat.isPinned"
-                :draggable="'true'"
-                class="app-grid-drag-handle"
-                @dragstart="onDragStart(app, $event)"
-              >
-                <q-icon name="drag_indicator" size="16px" color="white" />
-              </div>
-              <div
-                v-if="cat.isPinned"
-                class="app-grid-unpin-btn"
-                @click.stop="togglePin(app.id)"
-              >
-                <q-icon name="mdi-pin-off" size="14px" color="white" />
-              </div>
               <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">
                 <q-icon size="30px" color="white" :name="app.iconName" />
               </div>
@@ -737,15 +728,22 @@ export default {
       this.draggedAppId = null
       this.dragOverAppId = null
     },
+    onDragEnd (app) {
+      if (this.draggedAppId) {
+        this.togglePin(app.id)
+      }
+      this.draggedAppId = null
+      this.dragOverAppId = null
+    },
     showAppContextMenu (app, event) {
       if (!app.active) return
-      if (this.isPinned(app.id)) return
+      const pinned = this.isPinned(app.id)
       this.$q.bottomSheet({
         class: `text-bow ${this.getDarkModeClass(this.darkMode)}`,
         actions: [
           {
-            label: this.$t('Pin', {}, 'Pin'),
-            icon: 'mdi-pin',
+            label: pinned ? this.$t('Unpin', {}, 'Unpin') : this.$t('Pin', {}, 'Pin'),
+            icon: pinned ? 'mdi-pin-off' : 'mdi-pin',
             id: 'pin',
             color: this.themeColor,
           },
@@ -1290,49 +1288,16 @@ export default {
       max-width: calc(16.666% - 4px);
     }
     &.app-inactive { cursor: default; }
+    &[draggable="true"] {
+      cursor: grab;
+      &:active { cursor: grabbing; }
+    }
     &.drag-over {
       .app-grid-tile {
         outline: 3px solid rgba(59, 123, 246, 0.6);
         outline-offset: 3px;
       }
     }
-  }
-  .app-grid-drag-handle {
-    position: absolute;
-    top: -4px;
-    right: -4px;
-    z-index: 12;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    background: rgba(0,0,0,0.5);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: grab;
-    -webkit-user-select: none;
-    user-select: none;
-    &:active { cursor: grabbing; }
-    opacity: 0;
-    transition: opacity 0.2s ease;
-    .app-grid-item:hover & { opacity: 1; }
-  }
-  .app-grid-unpin-btn {
-    position: absolute;
-    top: -4px;
-    left: -4px;
-    z-index: 12;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    background: rgba(0,0,0,0.5);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    opacity: 0;
-    transition: opacity 0.2s ease;
-    .app-grid-item:hover & { opacity: 1; }
   }
   .app-grid-tile {
     width: 56px;

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -1378,7 +1378,6 @@ export default {
     &[draggable="true"] {
       cursor: grab;
       &:active { cursor: grabbing; }
-      img, i, span { -webkit-user-drag: none; user-drag: none; }
     }
     &.drag-over {
       .app-grid-tile {
@@ -1395,6 +1394,7 @@ export default {
     align-items: center;
     justify-content: center;
     &.tile-inactive { filter: grayscale(1) opacity(0.4); }
+    .app-grid-item[draggable="true"] & { pointer-events: none; }
   }
   .app-grid-name {
     margin: 6px 0 0;

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -104,7 +104,7 @@
             @dragover="cat.isPinned && dragSupported && onDragOver(app, $event)"
             @dragleave="cat.isPinned && dragSupported && onDragLeave()"
             @drop="cat.isPinned && dragSupported && onDrop(app, $event)"
-            @dragend="cat.isPinned && dragSupported && onDragEnd(app)"
+            @dragend="cat.isPinned && dragSupported && onDragEnd()"
           >
             <div
               v-if="cat.isPinned"
@@ -162,12 +162,12 @@
               { 'app-inactive': !app.active, 'drag-over': cat.isPinned && dragSupported && dragOverAppId === app.id }
             ]"
             @click="openApp(app)"
-            v-on-long-press="!cat.isPinned ? [(event) => showAppContextMenu(app, event)] : undefined"
+            v-on-long-press="(cat.isPinned && dragSupported) ? undefined : [(event) => showAppContextMenu(app, event)]"
             @dragstart="cat.isPinned && dragSupported && onDragStart(app, $event)"
             @dragover="cat.isPinned && dragSupported && onDragOver(app, $event)"
             @dragleave="cat.isPinned && dragSupported && onDragLeave()"
             @drop="cat.isPinned && dragSupported && onDrop(app, $event)"
-            @dragend="cat.isPinned && dragSupported && onDragEnd(app)"
+            @dragend="cat.isPinned && dragSupported && onDragEnd()"
           >
             <div class="relative-position" style="display: inline-block;">
               <div class="app-grid-tile bg-grad" :class="{ 'tile-inactive': !app.active }">

--- a/src/pages/apps/index.vue
+++ b/src/pages/apps/index.vue
@@ -78,9 +78,8 @@
         </div>
 
         <div
-          v-if="cat.isPinned && draggedAppId && dragSupported"
           class="unpin-bin"
-          :class="getDarkModeClass(darkMode)"
+          :class="[getDarkModeClass(darkMode), { 'unpin-bin-visible': cat.isPinned && draggedAppId && dragSupported }]"
           @dragover.prevent
           @drop="onUnpinDrop"
         >
@@ -1157,7 +1156,7 @@ export default {
     &.light { color: rgba(59, 123, 246, 0.6); }
   }
   .unpin-bin {
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
     gap: 8px;
@@ -1167,6 +1166,7 @@ export default {
     font-size: 13px;
     font-weight: 500;
     transition: background 0.15s ease, border-color 0.15s ease;
+    &.unpin-bin-visible { display: flex; }
     &.dark {
       background: rgba(239, 83, 80, 0.08);
       border: 2px dashed rgba(239, 83, 80, 0.4);


### PR DESCRIPTION
## Summary

This PR improves the Apps page with Payment Hub updates, a revamped pinned apps experience, and a more reliable long-press interaction.

## Changes

### Payment Hub
- Changed Payment Hub icon from custom image to Material `hub` icon
- Removed beta label from Payment Hub
- Moved Payment Hub from its own category to **Marketplace & Merchant**

### Pinned Apps: Drag-to-Reorder
- Pinned apps now respect the stored `pinnedAppIds` order in the `categorizedApps` computed property
- **List view**: Added a drag handle icon at the start of each pinned row — drag from there to reorder
- **Grid view**: The entire pinned item is draggable for reordering (no separate drag handle)
- Visual feedback: grab cursor on draggable items, dashed blue outline on list drop targets
- Reordering is persisted to `localStorage` immediately on drop

### Pinned Apps: Unpin
- **List view**: A pin-off icon appears in the row end area — click to unpin directly
- **Grid view**: Long press reveals a context menu with an **Unpin** option
- **List view**: Long press on a pinned app also shows the context menu with **Unpin** + **Open**
- Long press on the drag handle does not trigger the context menu (events stopped)
- Dragging a pinned item outside the Pinned section unpins it via `dragend`

### Long-Press Directive
- Replaced `@vueuse/components` `vOnLongPress` directive with a custom implementation
- Custom directive uses `touchstart`/`touchend` (mobile) and `mousedown`/`mouseup` (desktop)
- 500ms hold threshold, 10px movement cancellation to avoid triggering during scroll
- Resolves long-press reliability issues observed in the Capacitor WebView
