### PR TITLE
Fix cauldron swap keyboard not dismissing on swipe

### DIFF
--- a/src/pages/apps/cauldron/trade.vue
+++ b/src/pages/apps/cauldron/trade.vue
@@ -1056,6 +1056,7 @@ export default defineComponent({
     }
 
     function securityCheck(resetSwipe=() => {}) {
+      keyboardState.value = 'dismiss';
       $q.dialog({ component: SecurityCheckDialog })
         .onOk(() => commitTrade())
         .onCancel(() => resetSwipe?.())
@@ -1063,6 +1064,7 @@ export default defineComponent({
 
     async function commitTrade() {
       isSwapping.value = true;
+      keyboardState.value = 'dismiss';
       let dialog
       try {
         const _tokenData = selectedToken.value


### PR DESCRIPTION
## Problem

When swiping the slide button to confirm a swap in the Cauldron swap page, the custom keyboard panel remained visible throughout the entire swap process — including the security confirmation dialog, the progress dialog, and the success screen.

## Root Cause

The keyboard visibility was controlled by `keyboardState`, which was only being dismissed deep inside `commitTrade()` — after the security dialog and progress dialogs had already appeared. The `panelVisible` computed property kept the panel open because `keyboardState` remained `'show'`.

## Fix

- Added `keyboardState.value = 'dismiss'` at the start of `securityCheck()`, so the keyboard hides immediately when the user swipes
- Also kept the existing dismiss in `commitTrade()` as a safety net for any other code paths that call it

## Changes

```diff
 function securityCheck(resetSwipe=() => {}) {
+  keyboardState.value = 'dismiss';
   .dialog({ component: SecurityCheckDialog })
     .onOk(() => commitTrade())
     .onCancel(() => resetSwipe?.())
 }

 async function commitTrade() {
   isSwapping.value = true;
+  keyboardState.value = 'dismiss';
   let dialog
```