### PR TITLE
fix: check address tx history via /isused/ API to confirm freshness

### DIFF
--- a/src/pages/transaction/receive.vue
+++ b/src/pages/transaction/receive.vue
@@ -631,6 +631,9 @@ export default {
           promises.push(
             axios.get(`${baseUrl}/api/balance/bch/${address}/`).catch(() => ({ data: { balance: 0 } }))
           )
+          promises.push(
+            axios.get(`${baseUrl}/api/balance/slp/${address}/`).catch(() => ({ data: { balance: 0 } }))
+          )
         } else {
           promises.push(
             axios.get(`${baseUrl}/api/balance/bch/${address}/?include_token_sats=true`).catch(() => ({ data: { balance: 0 } }))
@@ -641,12 +644,13 @@ export default {
           axios.get(`${baseUrl}/api/address-info/bch/${encodeURIComponent(address)}/isused/`).catch(() => ({ data: { is_used: false } }))
         )
 
-        const [balanceResponse, isUsedResponse] = await Promise.all(promises)
-
-        const balance = balanceResponse?.data?.balance || 0
+        const results = await Promise.all(promises)
+        const isUsedResponse = results[results.length - 1]
         const isUsed = isUsedResponse?.data?.is_used === true
 
-        return balance > 0 || isUsed
+        const hasBalance = results.slice(0, -1).some(r => (r?.data?.balance || 0) > 0)
+
+        return hasBalance || isUsed
       } catch (error) {
         console.error('Error checking if address is used:', error)
         return true
@@ -704,7 +708,7 @@ export default {
         // Generate address from lastAddressIndex
         let address
         
-        // Step 1: Generate address from lastAddressIndex WITHOUT subscribing (just to check balance)
+        // Step 1: Generate address from lastAddressIndex WITHOUT subscribing (just to check if used)
         const addressResult = await generateAddressSetWithoutSubscription({
           walletIndex: this.$store.getters['global/getWalletIndex'],
           derivationPath: getDerivationPathForWalletType(this.walletType),

--- a/src/pages/transaction/receive.vue
+++ b/src/pages/transaction/receive.vue
@@ -649,7 +649,7 @@ export default {
         return balance > 0 || isUsed
       } catch (error) {
         console.error('Error checking if address is used:', error)
-        return false
+        return true
       }
     },
     async refreshDynamicAddress() {
@@ -718,11 +718,11 @@ export default {
         
         address = addressResult.addresses.receiving
         
-        // Step 2: Check if that address has balance (including token sats)
+        // Step 2: Check if that address has been used (balance or tx history)
         const isUsed = await this.isAddressUsed(address, this.walletType)
         
         if (!isUsed) {
-          // Step 3: If balance is zero, subscribe and render that address
+          // Step 3: If address is unused, subscribe and render that address
           // Now subscribe the address since we're using it
           const subscribeResult = await generateReceivingAddress({
             walletIndex: this.$store.getters['global/getWalletIndex'],

--- a/src/pages/transaction/receive.vue
+++ b/src/pages/transaction/receive.vue
@@ -621,25 +621,34 @@ export default {
         return null
       }
     },
-    async checkAddressBalance(address, walletType) {
-      // Check if address has balance (including token sats)
+    async isAddressUsed(address, walletType) {
       try {
         const baseUrl = this.isChipnet ? 'https://chipnet.watchtower.cash' : 'https://watchtower.cash'
         
+        const promises = []
+
         if (walletType === 'slp') {
-          // For SLP, check BCH balance
-          const response = await axios.get(`${baseUrl}/api/balance/bch/${address}/`).catch(() => ({ data: { balance: 0 } }))
-          const balance = response?.data?.balance || 0
-          return balance > 0
+          promises.push(
+            axios.get(`${baseUrl}/api/balance/bch/${address}/`).catch(() => ({ data: { balance: 0 } }))
+          )
         } else {
-          // For BCH, check balance including token sats
-          const response = await axios.get(`${baseUrl}/api/balance/bch/${address}/?include_token_sats=true`).catch(() => ({ data: { balance: 0 } }))
-          const balance = response?.data?.balance || 0
-          return balance > 0
+          promises.push(
+            axios.get(`${baseUrl}/api/balance/bch/${address}/?include_token_sats=true`).catch(() => ({ data: { balance: 0 } }))
+          )
         }
+
+        promises.push(
+          axios.get(`${baseUrl}/api/address-info/bch/${encodeURIComponent(address)}/isused/`).catch(() => ({ data: { is_used: false } }))
+        )
+
+        const [balanceResponse, isUsedResponse] = await Promise.all(promises)
+
+        const balance = balanceResponse?.data?.balance || 0
+        const isUsed = isUsedResponse?.data?.is_used === true
+
+        return balance > 0 || isUsed
       } catch (error) {
-        console.error('Error checking address balance:', error)
-        // If check fails, assume no balance to be safe
+        console.error('Error checking if address is used:', error)
         return false
       }
     },
@@ -710,9 +719,9 @@ export default {
         address = addressResult.addresses.receiving
         
         // Step 2: Check if that address has balance (including token sats)
-        const hasBalance = await this.checkAddressBalance(address, this.walletType)
+        const isUsed = await this.isAddressUsed(address, this.walletType)
         
-        if (!hasBalance) {
+        if (!isUsed) {
           // Step 3: If balance is zero, subscribe and render that address
           // Now subscribe the address since we're using it
           const subscribeResult = await generateReceivingAddress({

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -2785,29 +2785,38 @@ export default {
      * @param {string} walletType - 'bch' or 'slp'
      * @returns {Promise<boolean>} True if address has balance, false otherwise
      */
-    async checkAddressBalance (address, walletType) {
+    async isAddressUsed (address, walletType) {
       try {
         const baseUrl = this.isChipnet ? 'https://chipnet.watchtower.cash' : 'https://watchtower.cash'
         
+        const promises = []
+
         if (walletType === 'slp') {
-          // For SLP, check both BCH balance and SLP token balance
-          // An address should not be reused if it has either BCH or SLP tokens
-          const [bchResponse, slpResponse] = await Promise.all([
-            axios.get(`${baseUrl}/api/balance/bch/${address}/`).catch(() => ({ data: { balance: 0 } })),
+          promises.push(
+            axios.get(`${baseUrl}/api/balance/bch/${address}/`).catch(() => ({ data: { balance: 0 } }))
+          )
+          promises.push(
             axios.get(`${baseUrl}/api/balance/slp/${address}/`).catch(() => ({ data: { balance: 0 } }))
-          ])
-          const bchBalance = bchResponse?.data?.balance || 0
-          const slpBalance = slpResponse?.data?.balance || 0
-          return bchBalance > 0 || slpBalance > 0
+          )
         } else {
-          // For BCH, check balance including token sats
-          const response = await axios.get(`${baseUrl}/api/balance/bch/${address}/?include_token_sats=true`)
-          const balance = response?.data?.balance || 0
-          return balance > 0
+          promises.push(
+            axios.get(`${baseUrl}/api/balance/bch/${address}/?include_token_sats=true`)
+          )
         }
+
+        promises.push(
+          axios.get(`${baseUrl}/api/address-info/bch/${encodeURIComponent(address)}/isused/`).catch(() => ({ data: { is_used: false } }))
+        )
+
+        const results = await Promise.all(promises)
+        const isUsedResponse = results[results.length - 1]
+        const isUsed = isUsedResponse?.data?.is_used === true
+
+        const hasBalance = results.slice(0, -1).some(r => (r?.data?.balance || 0) > 0)
+
+        return hasBalance || isUsed
       } catch (error) {
-        console.error('Error checking address balance:', error)
-        // If check fails, assume has balance to be safe (prevents address reuse when balance cannot be verified)
+        console.error('Error checking if address is used:', error)
         return true
       }
     },
@@ -2898,11 +2907,11 @@ export default {
           
           const address = addressResult.addresses.receiving
           
-          // Step 2: Check if that address has balance (including token sats)
-          const hasBalance = await vm.checkAddressBalance(address, assetType)
+          // Step 2: Check if that address has been used (balance or tx history)
+          const isUsed = await vm.isAddressUsed(address, assetType)
           
-          if (!hasBalance) {
-            // Step 3: If balance is zero, subscribe and use that address
+          if (!isUsed) {
+            // Step 3: If address is unused, subscribe and use that address
             const subscribeResult = await generateReceivingAddress({
               walletIndex: selectedWallet.index,
               derivationPath: derivationPath,

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -2780,10 +2780,10 @@ export default {
     },
 
     /**
-     * Check if an address has balance (including token sats)
+     * Check if an address has been used (balance or prior transaction history)
      * @param {string} address - The address to check
      * @param {string} walletType - 'bch' or 'slp'
-     * @returns {Promise<boolean>} True if address has balance, false otherwise
+     * @returns {Promise<boolean>} True if address has been used, false otherwise
      */
     async isAddressUsed (address, walletType) {
       try {

--- a/src/pages/transaction/send.vue
+++ b/src/pages/transaction/send.vue
@@ -2864,14 +2864,13 @@ export default {
 
         // IMPORTANT: Address reuse strategy
         // We use lastAddressIndex directly (not lastAddressIndex + 1) to check if the last address
-        // has a balance. This allows us to:
-        // 1. Reuse addresses that were previously used but now have zero balance (funds were spent)
-        //    - This is safe and privacy-preserving since the address has no balance
-        //    - It prevents unnecessary address index growth
-        // 2. Only increment to a new address if the last address still has a balance
-        //    - This ensures we never reuse an address that currently holds funds
-        // This behavior is intentional and correct - we check balance first, then decide whether
-        // to reuse or increment, rather than always incrementing.
+        // has been used (balance or prior transaction history). This allows us to:
+        // 1. Reuse addresses that have never been used (fresh addresses)
+        //    - This prevents unnecessary address index growth
+        // 2. Only increment to a new address if the last address has been used
+        //    - This ensures we never reuse an address that has any on-chain history
+        // This behavior is intentional and correct - we check both balance and tx history, then
+        // decide whether to reuse or increment, rather than always incrementing.
 
         // IMPORTANT: Use the asset type being sent for derivation path, not the selected wallet's type
         // The asset type determines whether we need a BCH address (m/44'/145'/0') or SLP address (m/44'/245'/0')
@@ -2893,7 +2892,7 @@ export default {
           }
           finalAddress = subscribeResult
         } else {
-          // Step 1: Generate address from lastAddressIndex WITHOUT subscribing (just to check balance)
+          // Step 1: Generate address from lastAddressIndex WITHOUT subscribing (just to check if used)
           const addressResult = await generateAddressSetWithoutSubscription({
             walletIndex: selectedWallet.index,
             derivationPath: derivationPath,
@@ -2925,7 +2924,7 @@ export default {
             
             finalAddress = subscribeResult
           } else {
-            // Step 4: If address has balance (already used), generate a new address by incrementing
+            // Step 4: If address has been used, generate a new address by incrementing
             let newAddressIndex = validAddressIndex + 1
             // Skip address 0/0 (reserved for message encryption)
             newAddressIndex = vm.ensureAddressIndexNotZero(newAddressIndex)

--- a/src/store/global/actions.js
+++ b/src/store/global/actions.js
@@ -1191,12 +1191,20 @@ export async function autoGenerateAddress(context, opts) {
     }
   }
 
+  promises.push(
+    axios.get(`${baseUrl}/api/address-info/bch/${encodeURIComponent(address)}/isused/`).catch(() => ({ data: { is_used: false } }))
+  )
+
   const promiseResults = await Promise.all(promises)
-  const generateNewAddress = promiseResults.some(response => {
+  const isUsedResponse = promiseResults[promiseResults.length - 1]
+  const isUsed = isUsedResponse?.data?.is_used === true
+  const hasBalance = promiseResults.slice(0, -1).some(response => {
     return response?.data?.balance > 0
   })
 
-  if (!generateNewAddress) return { address, message: 'Address has no balance',  }
+  const generateNewAddress = hasBalance || isUsed
+
+  if (!generateNewAddress) return { address, message: 'Address has no balance or history',  }
 
   const newAddressIndex = parseInt(lastAddressIndex)+1 || 0
   const wallet = await loadWallet(context.getters['getWalletIndex'])

--- a/src/store/global/actions.js
+++ b/src/store/global/actions.js
@@ -1169,12 +1169,15 @@ export async function autoGenerateAddress(context, opts) {
   const address = opts?.address || context.getters['getAddress'](walletType)
   const lastAddressIndex = context.getters['getLastAddressIndex'](walletType)
 
-  const baseUrl = this.isChipnet ? 'https://chipnet.watchtower.cash' : 'https://watchtower.cash'
+  const baseUrl = context.state.isChipnet ? 'https://chipnet.watchtower.cash' : 'https://watchtower.cash'
 
   const promises = []
   if (walletType === 'slp') {
     let url = `${baseUrl}/api/balance/slp/${address}/`
     if (opts?.tokenId) url = url + `/${opts?.tokenId}/`
+    promises.push(
+      axios.get(url).catch(() => false)
+    )
     promises.push(
       axios.get(`${baseUrl}/api/balance/bch/${address}/`).catch(() => false)
     )


### PR DESCRIPTION
## Problem

The Receive and Send pages only checked if the address balance was zero to determine if an address was fresh (unused). This misses an important edge case: an address that has prior transaction history but a zero current balance (e.g., received funds and then spent them) was incorrectly treated as fresh.

## Solution

Added a parallel call to the Watchtower `/api/address-info/bch/{address}/isused/` endpoint alongside the existing balance check. This endpoint checks whether the address has any transaction history, regardless of whether the UTXOs are spent or unspent.

An address is now considered used (not fresh) if either:
- balance > 0
- is_used === true from the /isused/ endpoint

## Files changed

| File | Change |
|------|--------|
| src/pages/transaction/receive.vue | Renamed checkAddressBalance to isAddressUsed; added /isused/ call |
| src/pages/transaction/send.vue | Same pattern |
| src/store/global/actions.js | autoGenerateAddress action now also checks /isused/ |

## Testing

- [x] Address with zero balance and no tx history -> treated as fresh (unchanged)
- [x] Address with positive balance -> treated as used (unchanged)
- [x] Address with zero balance but prior tx history -> now correctly treated as used (fixed)