### PR TITLE
fix: wallet UI issues - send page layout and drag animation

### DIFF
--- a/src/components/multi-wallet/index.vue
+++ b/src/components/multi-wallet/index.vue
@@ -57,8 +57,9 @@
             :list="vault"
             @end="onDragEnd"
             :item-key="getWalletItemKey"
-            :animation="200"
+            :animation="600"
             :delay="200"
+            :transition-duration="600"
             :delay-on-touch-only="true"
             class="wallet-list-draggable"
           >
@@ -751,13 +752,19 @@ export default {
 
 .wallet-list-draggable {
   .sortable-ghost {
-    opacity: 0.4;
-    background: rgba(255, 255, 255, 0.1);
+    opacity: 0.3;
+    transform: scale(0.95);
   }
   
   .sortable-drag {
-    opacity: 0.8;
-    transform: rotate(2deg);
+    opacity: 0.9;
+    transform: scale(1.05);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+  }
+  
+  .sortable-chosen {
+    background-color: rgba(0, 0, 0, 0.05);
   }
 }
 

--- a/src/components/send-page/SendPageForm.vue
+++ b/src/components/send-page/SendPageForm.vue
@@ -175,6 +175,32 @@
       <KeyboardTooltip v-if="activeKeyboardTip === 'fiat'" :dark-mode="darkMode" :key="'fiat-' + keyboardTipCounter" />
     </div>
   </div>
+  <div class="row" v-if="!isNFT && !recipient.fixedAmount && !sending" style="padding-bottom: 15px">
+    <div class="col q-mt-md balance-max-container" :class="getDarkModeClass(darkMode)">
+      <template v-if="currentWalletBalanceAsAsset?.id === 'bch' && asset?.id === 'bch'">
+        <span v-bch-amount="{ denomination: selectedDenomination }">
+        {{ parseAssetDenomination(selectedDenomination, currentWalletBalanceAsAsset) }}
+      </span>
+        {{ ` = ${parseFiatCurrency(
+          convertToFiatAmount(currentWalletBalance, selectedAssetMarketPrice), currentSendPageCurrency())
+        }` }}
+      </template>
+      <span v-else v-bch-amount="{ denomination: selectedDenomination }">
+        {{ parseAssetDenomination(selectedDenomination, currentWalletBalanceAsAsset) }}
+      </span>
+      <q-btn
+        flat
+        dense
+        no-caps
+        v-if="!computingMax || !recipient.sending"
+        class="max-button"
+        color="pt-primary1"
+        :class="getDarkModeClass(darkMode)"
+        :label="$t('MAX')"
+        @click="onInputFocus(index, ''), handleMaxClick()"
+      />
+    </div>
+  </div>
   <template v-if="!isNFT && !cauldronEnabled">
     <div v-if="asset?.id?.startsWith?.('ct/')" class="q-mt-sm text-center">
       <div v-if="showAdvancedOptions">
@@ -308,33 +334,6 @@
       round
       @click="toggleCauldron"
     />
-  </div>
-
-  <div class="row" v-if="!isNFT && !recipient.fixedAmount && !sending" style="padding-bottom: 15px">
-    <div class="col q-mt-md balance-max-container" :class="getDarkModeClass(darkMode)">
-      <template v-if="currentWalletBalanceAsAsset?.id === 'bch' && asset?.id === 'bch'">
-        <span v-bch-amount="{ denomination: selectedDenomination }">
-        {{ parseAssetDenomination(selectedDenomination, currentWalletBalanceAsAsset) }}
-      </span>
-        {{ ` = ${parseFiatCurrency(
-          convertToFiatAmount(currentWalletBalance, selectedAssetMarketPrice), currentSendPageCurrency())
-        }` }}
-      </template>
-      <span v-else v-bch-amount="{ denomination: selectedDenomination }">
-        {{ parseAssetDenomination(selectedDenomination, currentWalletBalanceAsAsset) }}
-      </span>
-      <q-btn
-        flat
-        dense
-        no-caps
-        v-if="!computingMax || !recipient.sending"
-        class="max-button"
-        color="pt-primary1"
-        :class="getDarkModeClass(darkMode)"
-        :label="$t('MAX')"
-        @click="onInputFocus(index, ''), handleMaxClick()"
-      />
-    </div>
   </div>
   <q-card
     class="row text-center justify-center q-pa-sm q-my-sm text-subtitle2 pt-card"


### PR DESCRIPTION
## Changes

### Send Page Layout
- Moved the wallet balance + MAX button div above the "Show Advanced Options" section so the balance is always visible first before expanding advanced options.

### Wallet Sidebar Drag Animation
- Increased  from 200ms to 600ms and added  to match the smooth drag-to-reorder animation from the asset list page.
- Updated  CSS:  with  for a cohesive visual placeholder.
- Updated  CSS:  with , , and  for a lifted, polished dragging feel.
- Added  style with subtle background highlight.

These changes make the wallet reorder UX consistent with the asset list page's smooth animation style.