### PR TITLE
transpile mainnet-js for iOS 16.2 compatibility

### DIFF
--- a/quasar.config.cjs
+++ b/quasar.config.cjs
@@ -162,6 +162,20 @@ module.exports = defineConfig((ctx) => {
               }
             }
           })
+
+          cfg.module.rules.push({
+            test: /\.(?:js|mjs|cjs|vue)$/,
+            enforce: 'post',
+            include: /node_modules\/mainnet-js/,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                presets: [
+                  ['@babel/preset-env', { targets: { ios: '16.2' }, modules: false }]
+                ],
+              },
+            }
+          })
         }
 
         if (cfg.mode === 'production') {


### PR DESCRIPTION
## Description
transpile mainnet-js for iOS 16.2 compatibility, fix for white screen bug observed in iPhone 13, ios 16.2, devices.

Fixes # (issue)

## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [ ] UI improvements with no business logic changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Installed on simulators: iphone 13 (ios 16) & iphone 17 (ios 26)
- Tested sending/receiving

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
