### PR TITLE
Improve P2P Ramp onboarding UX: auto-select payment methods & add swipe shimmer

### DIFF
--- a/src/components/ramp/fiat/AddPaymentMethods.vue
+++ b/src/components/ramp/fiat/AddPaymentMethods.vue
@@ -200,7 +200,7 @@
     :payment-method-id="selectedMethodIndex"
     :payment-type="info"
     :currency="currencyContext || currency"
-    @success="fetchPaymentMethods"
+    @success="onPaymentMethodSuccess"
     @back="onPaymentMethodBack"/>
   <div v-if="!isloaded" class="q-mx-md">
     <!-- Title skeleton -->
@@ -421,6 +421,14 @@ export default {
       this.showPaymentMethodForm = false
       this.showSelectPaymentMethods = false
       this.showMiscDialogs = false
+    },
+    async onPaymentMethodSuccess () {
+      const createdPaymentTypeId = this.info?.payment_type?.id || this.info?.id
+      await this.fetchPaymentMethods()
+      if (this.type === 'General' && createdPaymentTypeId) {
+        const newlyCreated = this.paymentMethods.filter(p => p.payment_type?.id === createdPaymentTypeId && !this.isPaymentSelected(p))
+        this.selectedMethods.push(...newlyCreated)
+      }
     },
     receiveDialogInfo (data) {
       const vm = this

--- a/src/components/ramp/fiat/dialogs/RampDragSlide.vue
+++ b/src/components/ramp/fiat/dialogs/RampDragSlide.vue
@@ -10,7 +10,7 @@
               {{ $t('SecurityCheck') }}
             </div>
           </template>
-          <q-item class="bg-grad text-white q-py-sm">
+          <q-item class="bg-grad text-white q-py-sm" :class="{ 'drag-slide-active': !locked }">
             <q-item-section avatar>
               <q-icon v-if="locked" name="lock" size="sm" :class="`bg-${themeColor}`" class="q-pa-sm" style="border-radius: 50%" />
               <q-icon v-else name="mdi-chevron-double-right" size="lg" :class="`bg-${themeColor}`" style="border-radius: 50%" />
@@ -216,6 +216,30 @@ export default {
   }
 }
 
+/* Active (enabled) button: constant shimmer sweep */
+.drag-slide-active {
+  position: relative;
+  overflow: hidden;
+}
+.drag-slide-active::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 55%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.12), rgba(255,255,255,0.15), transparent);
+  clip-path: polygon(0% 0%, 65% 0%, 100% 50%, 65% 100%, 0% 100%, 25% 50%);
+  transform: translateX(-100%);
+  animation: shimmer-sweep 2.8s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes shimmer-sweep {
+  0% { transform: translateX(-100%); }
+  45% { transform: translateX(160%); }
+  100% { transform: translateX(160%); }
+}
+
 /* Attention nudge: subtle shine + pulse */
 .ramp-drag-slide-container.nudge {
   :deep(.q-item.bg-grad) {
@@ -237,6 +261,12 @@ export default {
   }
   :deep(.q-icon.mdi-chevron-double-right) {
     animation: swipeNudgeChevron 1.0s ease-in-out infinite;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drag-slide-active::after {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Two UX improvements for P2P Ramp:

### 1. Auto-select newly created payment methods for new peers
When a new peer (new user) is on the "add payment methods" page (`AddPaymentMethods` in the `General` flow), any payment method they just entered via the form is now automatically selected/checked. Previously the peer had to manually tap the check button on each newly created method before continuing.

### 2. Shimmer animation on the enabled swipe-to-escrow button
The swipe-to-escrow button on the order page now shows the same shining shimmer animation as the active slide buttons on other pages. The `RampDragSlide` component reuses the `shimmer-sweep` style from `drag-slide.vue`, applied whenever the button is enabled (not locked via `drag-slide-active` class).

## Changes

- `src/components/ramp/fiat/AddPaymentMethods.vue`: add `onPaymentMethodSuccess` handler that auto-adds the created payment method to `selectedMethods` after a successful save (General/new-peer flow only).
- `src/components/ramp/fiat/dialogs/RampDragSlide.vue`: add `drag-slide-active` class + shimmer-sweep animation for enabled buttons, with `prefers-reduced-motion` support.

## Testing

- Verified `npm run lint` passes for both changed files.