### PR TITLE
fix: WalletConnect & WizardConnect transaction signing and broadcast

### DIFF
--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1366,6 +1366,11 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
       }
       sessionRequest.error = true
       processingSession.value[sessionRequest.topic] = 'Sending error response'
+      $q.notify({
+        type: 'error',
+        message: err?.message || 'Failed to sign transaction',
+        timeout: 5000
+      })
     } finally {
       $q.loading.hide(loadingKey)
     }
@@ -1400,6 +1405,11 @@ const respondToSignMessageRequest = async (sessionRequest) => {
     }
     sessionRequest.error = true
     processingSession.value[sessionRequest.topic] = 'Sending error response'
+    $q.notify({
+      type: 'error',
+      message: err?.message || 'Failed to sign message',
+      timeout: 5000
+    })
   } finally {
     if (!response.result) delete response.result
     if (!response.error) delete response.error

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1334,9 +1334,9 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
       )
 
       const broadcastResponse = await watchtower.value?.BCH.broadcastTransaction(response.result.signedTransaction)
-      if (!broadcastResponse?.success) {
+      if (!broadcastResponse?.data?.success) {
         console.error('Broadcast failed:', broadcastResponse)
-        response.error = { code: -32603, message: broadcastResponse?.error || 'Broadcast failed' }
+        response.error = { code: -32603, message: broadcastResponse?.data?.error || 'Broadcast failed' }
         response.result = undefined
       }
 

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1260,6 +1260,7 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
   const response = { id: sessionRequest.id, jsonrpc: '2.0', result: undefined, error: undefined }
   if (sessionRequest?.params?.request?.method === 'bch_signTransaction' || sessionRequest?.params?.request?.method === 'bch_signTransactionP2SHMultisig') {
     const loadingKey = 'wc-sign-transaction'
+    let responseSent = false
     try {
       const wallet = sessionTopicWalletAddressMapping.value?.[sessionRequest.topic]
       if (wallet.signers) {
@@ -1297,6 +1298,7 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
             }
           }
         })
+        responseSent = true
 
         $q.loading.show({ group: loadingKey, message: $t('ProcessingTransactionProposal') })
 
@@ -1338,31 +1340,16 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
         console.error('Broadcast failed:', broadcastResponse)
         response.error = { code: -32603, message: broadcastResponse?.data?.error || 'Broadcast failed' }
         response.result = undefined
+        sessionRequest.error = true
       }
 
       processingSession.value[sessionRequest.topic] = 'Confirming request'
-
-      if (!response.result) delete response.result
-      if (!response.error) delete response.error
-      
-      await web3Wallet.value.respondSessionRequest({
-        topic: sessionRequest.topic, response
-      })
-
-      if (!sessionRequest.error) {
-        sessionRequest.confirmed = true
-      }
-
-      delete processingSession.value[sessionRequest.topic]
-      
-      await delay(2)
-      await loadSessionRequests()
 
     } catch (err) {
       console.error(err)
       response.error = {
         code: -32603,
-        reason: err?.name === 'SignBCHTransactionError' ? err?.message : 'Unknown error'
+        message: err?.name === 'SignBCHTransactionError' ? err?.message : 'Unknown error'
       }
       sessionRequest.error = true
       processingSession.value[sessionRequest.topic] = 'Sending error response'
@@ -1372,6 +1359,19 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
         timeout: 5000
       })
     } finally {
+      if (!responseSent) {
+        if (!response.result) delete response.result
+        if (!response.error) delete response.error
+        await web3Wallet.value.respondSessionRequest({
+          topic: sessionRequest.topic, response
+        })
+        if (!sessionRequest.error) {
+          sessionRequest.confirmed = true
+        }
+        delete processingSession.value[sessionRequest.topic]
+        await delay(2)
+        await loadSessionRequests()
+      }
       $q.loading.hide(loadingKey)
     }
   }

--- a/src/components/walletconnect/WalletConnectV2.vue
+++ b/src/components/walletconnect/WalletConnectV2.vue
@@ -1333,12 +1333,11 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
         wallet.wif
       )
 
-      if (sessionRequest.params.request.params?.broadcast) {
-        const broadcastResponse = watchtower.value?.BCH.broadcastTransaction(response.result.signedTransaction)
-        if (!broadcastResponse.success) {
-          response.error = { code: -32603, message: broadcastResponse?.error }
-          response.result = undefined
-        }
+      const broadcastResponse = await watchtower.value?.BCH.broadcastTransaction(response.result.signedTransaction)
+      if (!broadcastResponse?.success) {
+        console.error('Broadcast failed:', broadcastResponse)
+        response.error = { code: -32603, message: broadcastResponse?.error || 'Broadcast failed' }
+        response.result = undefined
       }
 
       processingSession.value[sessionRequest.topic] = 'Confirming request'
@@ -1360,6 +1359,7 @@ const respondToSignTransactionRequest = async (sessionRequest) => {
       await loadSessionRequests()
 
     } catch (err) {
+      console.error(err)
       response.error = {
         code: -32603,
         reason: err?.name === 'SignBCHTransactionError' ? err?.message : 'Unknown error'
@@ -1393,6 +1393,7 @@ const respondToSignMessageRequest = async (sessionRequest) => {
     response.result = signMessage(message, connectedAddressForTopic.wif)
     processingSession.value[sessionRequest.topic] = 'Confirming request'
   } catch (err) {
+    console.error(err)
     response.error = {
       code: -32603,
       message: err?.message || 'Unknown error'
@@ -1473,6 +1474,7 @@ const respondToSessionRequest = async (sessionRequest) => {
       }
     }
   } catch (error) {
+    console.error(error)
   } finally {
     delete processingSession.value[sessionRequest.id]
   }

--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -216,9 +216,9 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     const watchtower = new Watchtower(isChipnet)
 
     const broadcastResponse = await watchtower.BCH.broadcastTransaction(signedTxHex)
-    if (!broadcastResponse?.success) {
+    if (!broadcastResponse?.data?.success) {
       console.error('WizardConnect: broadcast failed:', broadcastResponse)
-      await wizardConnectService.sendSignError(connectionId, sequence, broadcastResponse?.error || 'Broadcast failed')
+      await wizardConnectService.sendSignError(connectionId, sequence, broadcastResponse?.data?.error || 'Broadcast failed')
       return
     }
 

--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -215,12 +215,13 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     const isChipnet = rootGetters['global/isChipnet'] || false
     const watchtower = new Watchtower(isChipnet)
 
-    if (request.transaction?.broadcast === true) {
-      watchtower.BCH.broadcastTransaction(signedTxHex).catch(err => {
-        console.log('WizardConnect: wallet-side broadcast (redundant) failed or tx already known:', err)
-      })
+    const broadcastResponse = await watchtower.BCH.broadcastTransaction(signedTxHex)
+    if (!broadcastResponse?.success) {
+      console.error('WizardConnect: broadcast failed:', broadcastResponse)
+      await wizardConnectService.sendSignError(connectionId, sequence, broadcastResponse?.error || 'Broadcast failed')
+      return
     }
-    
+
     await wizardConnectService.sendSignResponse(connectionId, sequence, signedTxHex)
     
     // After transaction, check buffer (delayed to allow backend to process)

--- a/src/store/wizardconnect/actions.js
+++ b/src/store/wizardconnect/actions.js
@@ -218,6 +218,11 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     const broadcastResponse = await watchtower.BCH.broadcastTransaction(signedTxHex)
     if (!broadcastResponse?.data?.success) {
       console.error('WizardConnect: broadcast failed:', broadcastResponse)
+      Notify.create({
+        type: 'negative',
+        message: broadcastResponse?.data?.error || 'Broadcast failed',
+        timeout: 5000
+      })
       await wizardConnectService.sendSignError(connectionId, sequence, broadcastResponse?.data?.error || 'Broadcast failed')
       return
     }
@@ -230,6 +235,11 @@ export async function approveRequestWithData ({ commit, dispatch, rootGetters },
     }, 2000)
   } catch (err) {
     console.error('WizardConnect: sign error:', err)
+    Notify.create({
+      type: 'negative',
+      message: err.message || 'Failed to sign transaction',
+      timeout: 5000
+    })
     try {
       await wizardConnectService.sendSignError(connectionId, sequence, err.message || 'Signing failed')
     } catch {

--- a/src/wallet/bch-sign.js
+++ b/src/wallet/bch-sign.js
@@ -3,6 +3,8 @@ import {
   walletTemplateP2pkhNonHd,
   walletTemplateToCompilerBCH,
   binToHex,
+  decodeAuthenticationInstructions,
+  encodeAuthenticationInstructions,
   encodeLockingBytecodeP2pkh,
   encodeTransaction,
   generateSigningSerializationBCH,
@@ -85,7 +87,25 @@ export function signBchTransaction({ transaction, sourceOutputs, resolveKey, pre
 
       // Verify the redeem script matches the locking bytecode's script hash
       // This prevents malicious dApps from substituting a different contract's redeem script
-      const coveredBytecode = sourceOutputs[index].contract?.redeemScript
+      let coveredBytecode = sourceOutputs[index].contract?.redeemScript
+      if (!coveredBytecode) {
+        const decoded = decodeAuthenticationInstructions(sourceOutput.unlockingBytecode)
+        let script = (decoded.splice(-1)[0])?.data
+        if (script?.length) {
+          let prevHash
+          do {
+            prevHash = binToHex(script)
+            const decodedScript = decodeAuthenticationInstructions(script)
+            const first = decodedScript.splice(0, 1)[0]
+            if (first && first.opcode <= 96) {
+              script = encodeAuthenticationInstructions(decodedScript)
+            } else {
+              break
+            }
+          } while (prevHash !== binToHex(script))
+        }
+        coveredBytecode = script
+      }
       if (!coveredBytecode) {
         throw signBchTxError('Not enough information provided, please include contract redeemScript')
       }
@@ -94,14 +114,20 @@ export function signBchTransaction({ transaction, sourceOutputs, resolveKey, pre
       const p2sh32Match = lockBytecodeHex.match(/^aa20([0-9a-f]{64})87$/)
       if (p2sh20Match) {
         const expectedHash = p2sh20Match[1]
-        const actualHash = binToHex(hash160(hexToBin(coveredBytecode)))
+        const actualHash = binToHex(hash160(coveredBytecode))
         if (actualHash !== expectedHash) {
           throw signBchTxError('Redeem script does not match P2SH locking bytecode')
         }
       } else if (p2sh32Match) {
         const expectedHash = p2sh32Match[1]
-        const actualHash = binToHex(hash256(hexToBin(coveredBytecode)))
+        const actualHash = binToHex(hash256(coveredBytecode))
         if (actualHash !== expectedHash) {
+          console.error('P2SH32 locking bytecode mismatch', {
+            lockingBytecode: lockBytecodeHex,
+            expectedHash,
+            actualHash,
+            coveredBytecode: binToHex(coveredBytecode)
+          })
           throw signBchTxError('Redeem script does not match P2SH32 locking bytecode')
         }
       } else {

--- a/src/wallet/bch-sign.js
+++ b/src/wallet/bch-sign.js
@@ -54,6 +54,32 @@ export function signBchTxError(...args) {
 }
 
 /**
+ * Extract the contract (redeem) script from an unlocking bytecode by taking
+ * the last authentication instruction and stripping leading constructor
+ * parameter pushes until reaching the raw contract bytecode body.
+ * @param {Uint8Array} unlockingBytecode
+ * @returns {Uint8Array|undefined}
+ */
+export function extractContractBytecode(unlockingBytecode) {
+  const decoded = decodeAuthenticationInstructions(unlockingBytecode)
+  let script = (decoded.splice(-1)[0])?.data
+  if (script?.length) {
+    let prevHash
+    do {
+      prevHash = binToHex(script)
+      const decodedScript = decodeAuthenticationInstructions(script)
+      const first = decodedScript.splice(0, 1)[0]
+      if (first && first.opcode <= 96) {
+        script = encodeAuthenticationInstructions(decodedScript)
+      } else {
+        break
+      }
+    } while (prevHash !== binToHex(script))
+  }
+  return script
+}
+
+/**
  * Sign a BCH transaction, handling both P2PKH and CashScript contract inputs.
  *
  * @param {Object} params
@@ -89,22 +115,7 @@ export function signBchTransaction({ transaction, sourceOutputs, resolveKey, pre
       // This prevents malicious dApps from substituting a different contract's redeem script
       let coveredBytecode = sourceOutputs[index].contract?.redeemScript
       if (!coveredBytecode) {
-        const decoded = decodeAuthenticationInstructions(sourceOutput.unlockingBytecode)
-        let script = (decoded.splice(-1)[0])?.data
-        if (script?.length) {
-          let prevHash
-          do {
-            prevHash = binToHex(script)
-            const decodedScript = decodeAuthenticationInstructions(script)
-            const first = decodedScript.splice(0, 1)[0]
-            if (first && first.opcode <= 96) {
-              script = encodeAuthenticationInstructions(decodedScript)
-            } else {
-              break
-            }
-          } while (prevHash !== binToHex(script))
-        }
-        coveredBytecode = script
+        coveredBytecode = extractContractBytecode(sourceOutput.unlockingBytecode)
       }
       if (!coveredBytecode) {
         throw signBchTxError('Not enough information provided, please include contract redeemScript')

--- a/src/wallet/walletconnect2/index.js
+++ b/src/wallet/walletconnect2/index.js
@@ -339,7 +339,8 @@ export function parseSessionRequest(sessionRequest) {
     }
 
     parsedTx?.outputs?.forEach?.(populateOutputAddress)
-    parsedParams?.sourceOutputs?.forEach?.(populateOutputAddress)?.forEach(unpackSourceOutput)
+    parsedParams?.sourceOutputs?.forEach?.(populateOutputAddress)
+    parsedParams?.sourceOutputs?.forEach?.(unpackSourceOutput)
 
     parsedTx?.inputs?.forEach?.(input => {
       input.sourceOutput = parsedParams?.sourceOutputs?.find?.(output => {

--- a/src/wallet/walletconnect2/tx-sign-utils.js
+++ b/src/wallet/walletconnect2/tx-sign-utils.js
@@ -1,47 +1,29 @@
 import { binToHex, decodeAuthenticationInstructions, encodeAuthenticationInstructions } from 'bitauth-libauth-v3'
 
-// Re-export shared utilities for backward compatibility
 export { parseExtendedJson, privateKeyToCashAddress, signBchTxError } from '../bch-sign'
 
 export function unpackSourceOutput(sourceOutput) {
   const contractName = sourceOutput?.contract?.artifact?.contractName;
-  if (!contractName) return sourceOutput
+  if (!contractName) return
   const decoded = decodeAuthenticationInstructions(sourceOutput?.unlockingBytecode)
   const redeemScript = (decoded.splice(-1)[0])?.data;
   if (redeemScript?.length) {
     let script = redeemScript.slice();
-    let artifact = artifactMap[binToHex(script)]
-    while (!artifact) {
+    let lastScriptHash;
+    do {
+      lastScriptHash = binToHex(script);
       const decodedScript = decodeAuthenticationInstructions(script);
-      const [{ opcode }] = decodedScript.splice(0,1);
-
-      // if the opcode is a data push, we strip it and continue
-      if (opcode <= 96 /* OP_16 */) {
+      const first = decodedScript.splice(0, 1)[0];
+      if (first && first.opcode <= 96) {
         script = encodeAuthenticationInstructions(decodedScript);
-        artifact = artifactMap[binToHex(script)];
       } else {
-        return sourceOutput;
+        break;
       }
-    }
+    } while (lastScriptHash !== binToHex(script) && script.length < redeemScript.length);
 
-    let abiFunction
-    if (artifact.abi.length > 1) {
-      // expect to N abi parameters + 1 function index push
-      const abiFunctionIndex = Number(BigInt((decoded.splice(-1)[0]).data));
-      abiFunction = artifact.abi[abiFunctionIndex];
-    } else {
-      abiFunction = artifact.abi[0];
-    }
     sourceOutput.contract = {
       ...sourceOutput.contract,
-      artifact: {
-        contractName: artifact.contractName
-      },
-      abiFunction: {
-        name: abiFunction.name,
-        inputs: undefined
-      },
-      redeemScript: undefined
+      redeemScript: script
     }
   }
 }

--- a/src/wallet/walletconnect2/tx-sign-utils.js
+++ b/src/wallet/walletconnect2/tx-sign-utils.js
@@ -1,29 +1,15 @@
-import { binToHex, decodeAuthenticationInstructions, encodeAuthenticationInstructions } from 'bitauth-libauth-v3'
+import { binToHex } from 'bitauth-libauth-v3'
 
-export { parseExtendedJson, privateKeyToCashAddress, signBchTxError } from '../bch-sign'
+export { parseExtendedJson, privateKeyToCashAddress, signBchTxError, extractContractBytecode } from '../bch-sign'
 
 export function unpackSourceOutput(sourceOutput) {
   const contractName = sourceOutput?.contract?.artifact?.contractName;
   if (!contractName) return
-  const decoded = decodeAuthenticationInstructions(sourceOutput?.unlockingBytecode)
-  const redeemScript = (decoded.splice(-1)[0])?.data;
-  if (redeemScript?.length) {
-    let script = redeemScript.slice();
-    let lastScriptHash;
-    do {
-      lastScriptHash = binToHex(script);
-      const decodedScript = decodeAuthenticationInstructions(script);
-      const first = decodedScript.splice(0, 1)[0];
-      if (first && first.opcode <= 96) {
-        script = encodeAuthenticationInstructions(decodedScript);
-      } else {
-        break;
-      }
-    } while (lastScriptHash !== binToHex(script) && script.length < redeemScript.length);
-
+  const redeemScript = extractContractBytecode(sourceOutput?.unlockingBytecode)
+  if (redeemScript?.length && binToHex(redeemScript) !== binToHex(sourceOutput?.contract?.redeemScript)) {
     sourceOutput.contract = {
       ...sourceOutput.contract,
-      redeemScript: script
+      redeemScript
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes several WalletConnect and WizardConnect transaction signing/broadcast bugs found while testing reputable dApps. Contract-based (CashToken/CashScript) transactions were failing the P2SH32 redeem-script validation, broadcasts were never confirmed (and the success check was broken), and users weren't informed when signing failed.

## Bug fixes

### 1. Correct redeem-script extraction for contract inputs

The `unpackSourceOutput` pipeline had multiple bugs that prevented the actual redeem script from being extracted from the unlocking bytecode:

- **Dead `forEach` chain** — `sourceOutputs.forEach(...).forEach(unpackSourceOutput)` never executed `unpackSourceOutput` because `Array.prototype.forEach` returns `undefined`, causing the optional-chaining `?.forEach` to short-circuit (`src/wallet/walletconnect2/index.js`)
- **Broken `artifactMap` reference** — `unpackSourceOutput` referenced an `artifactMap` that was never defined in scope, which would crash at runtime
- **`redeemScript` set to `undefined`** — the function clobbered the redeem script it was meant to extract

`unpackSourceOutput` was rewritten to extract the true redeem script from the unlocking bytecode (last auth instruction) and normalize the contract data without the unmaintained artifact map.

### 2. Fix P2SH32 validation corruption (`src/wallet/bch-sign.js`)

`hash256(hexToBin(coveredBytecode))` was silently corrupting data on contract inputs. `coveredBytecode` is already a `Uint8Array`, and calling `hexToBin()` on a `Uint8Array` invokes `toString()` which produces **comma-separated decimal byte values** (`"116,99,118,..."`) — not hex. That garbage was hashed instead of the real redeem script, so validation always failed for legitimate dApps.

Fixed by passing the binary `Uint8Array` directly to `hash256`. Also added a `decodeAuthenticationInstructions` fallback to recover the redeem script from the unlocking bytecode when it's not available in `contract.redeemScript`.

The validation itself (ensuring `hash256(redeemScript)` matches the hash in the P2SH32 locking bytecode) is preserved — this is what protects against a dApp presenting one contract in the UI while signing for a different one.

### 3. Reliable broadcasting + correct success check

**WalletConnectV2** (`src/components/walletconnect/WalletConnectV2.vue`):
- Broadcast was missing `await` and gated behind the dApp's `broadcast` flag
- Success check used `broadcastResponse?.success` — but `BCH.broadcastTransaction()` returns a raw axios response, so the success flag actually lives at `broadcastResponse.data.success`. The old check always evaluated falsy

**WizardConnect** (`src/store/wizardconnect/actions.js`):
- Broadcast was fire-and-forget (`.catch()` only), gated behind the dApp flag, and never surfaced failures to the dApp

Both now **always broadcast** to Watchtower regardless of the dApp's flag (the dApp may rebroadcast harmlessly), `await` the result, and check `broadcastResponse.data.success`. Broadcast failures are reported back to the dApp as a sign error.

### 4. User-facing error notifications

Signing/broadcast failures were only written to the console or shown as an unlabeled error icon. Now:
- **WalletConnectV2** — `$q.notify` error toast on transaction/message signing failures
- **WizardConnect** — `Notify.create` error toast on signing/broadcast failures
- Added `console.error` logging in the previously-empty catch blocks

## Files changed

| File | Change |
|---|---|
| `src/wallet/walletconnect2/tx-sign-utils.js` | Rewrote `unpackSourceOutput` — extract real redeem script, drop broken `artifactMap` dep |
| `src/wallet/walletconnect2/index.js` | Fixed dead `forEach` chain so `unpackSourceOutput` actually runs |
| `src/wallet/bch-sign.js` | Fixed `hexToBin` corruption on `Uint8Array`, added unlocking-bytecode fallback |
| `src/components/walletconnect/WalletConnectV2.vue` | Always broadcast with `await`, correct success check, error toasts + logging |
| `src/store/wizardconnect/actions.js` | Always broadcast with `await`, correct success check, errors to dApp + toasts |

## Testing

Manual testing with several reputable CashToken/CashScript dApps:
- P2SH32 validation now passes (previously always failed for legitimate dApps)
- Transactions broadcast and confirm successfully