### PR TITLE
fix: recover push notification from stash when cleared during app lock

### DIFF
--- a/src/pages/push-notification-router.vue
+++ b/src/pages/push-notification-router.vue
@@ -135,10 +135,12 @@ async function handleOpenedNotification() {
   
   loadingMsg.value = t('ResolvingRoute') + '...'
 
-  // The in-memory notification can be gone by the time we get here (e.g. it
-  // was cleared while the app was locked on the lock screen) — recover from
-  // the boot stash, which is kept until the flow completes
-  if (!openedNotification.value) {
+  // The in-memory notification can be wiped while the app is locked (e.g. the
+  // appStateChange listener clears it on the lock screen). A cleared
+  // notification is the default truthy object with an empty id — NOT null — so
+  // emptiness must be checked via id. Recover from the boot stash, which is
+  // kept until the flow completes.
+  if (!openedNotification.value?.id) {
     try {
       const stashedNotification = localStorage.getItem('push_opened_notification')
       if (stashedNotification) {


### PR DESCRIPTION
## Summary

When the currently-active wallet had app lock enabled and the app was cold-started via a push notification intended for a *different* wallet, the app would unlock but stay on the home screen instead of switching wallets and navigating to the notification's destination. All other wallet-switch paths (app already unlocked, app in background, etc.) worked correctly.

## Root cause

Cold-start flow: boot stashes the opened notification (`localStorage.push_opened_notification`) → App.vue pushes to `push-notification-router` → the route guard redirects to `/lock` (active wallet is locked) → after unlock, `push-notification-router.vue` re-processes the notification.

While the biometric prompt was on screen, the app became *inactive*, which fired the boot listener's `appStateChange` handler and called `clearOpenedNotification`. That mutation does **not** reset `openedNotification` to `null` — it resets it to a truthy default placeholder object (`{id:'', ..., data:{type:''}}`, see `src/store/notification/state.js`).

The stash-recovery guard introduced in #765, `if (!openedNotification.value)`, therefore never fired — it was dead code. The router resolved the destination from the wiped placeholder object, found no `data.type` / `wallet_hash`, and fell through to `replace('/')` (home).

## Fix

In `src/pages/push-notification-router.vue`, treat the notification as empty when `!openedNotification.value?.id` instead of `!openedNotification.value`. Capacitor push payloads always carry an `id`, so a genuinely opened notification is distinguishable from the cleared placeholder, and the notification is correctly recovered from the stash after unlock.

## Testing

- iOS device, cold start via push notification with the active wallet locked:
  - Before: unlock → home, no wallet switch.
  - After: unlock → "Switching wallet..." → destination route on the notification's wallet (one extra unlock if the destination wallet also has app lock).
- Verified all other wallet-switch scenarios still behave as before.

Refs #765