### PR TITLE
feat(cauldron): cap platform fee at 1 USD worth of BCH

### DIFF
--- a/src/i18n/__texts/phrases.js
+++ b/src/i18n/__texts/phrases.js
@@ -335,6 +335,7 @@ const phrases = {
       TransactionIdCopied: 'Transaction ID copied',
       InvalidTradeResult: 'Invalid trade result. Please try again.',
       PlatformFee: 'Platform Fee',
+      PlatformFeeInfo: 'A 0.3% fee charged by the platform, capped at a maximum of 1 USD worth of BCH.',
       TradeSummary: 'Trade Summary',
       ExchangeRate: 'Exchange rate',
       TotalPlatformFee: 'Total Platform Fee',

--- a/src/i18n/af/index.js
+++ b/src/i18n/af/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Plan Naam",
   Plans: "Planne",
   PlatformFee: "Platformfooi",
+  PlatformFeeInfo: "'n 0.3% fooi wat deur die platform gehef word, beperk tot 'n maksimum van 1 USD ter waarde van BCH.",
   PleaseEnableLocationService: "Aktiveer asseblief toestel se liggingdiens.",
   PleaseEnterNickname: "Voer asseblief bynaam in",
   PleaseEnterOrScanEncryptionPublicKey: "Voer asseblief die enkripsie publieke sleutel in of skandeer dit",

--- a/src/i18n/ar/index.js
+++ b/src/i18n/ar/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "اسم الخطة",
   Plans: "الخطط",
   PlatformFee: "رسوم المنصة",
+  PlatformFeeInfo: "رسوم بنسبة 0.3% تفرضها المنصة، بحد أقصى 1 دولار أمريكي من عملة البيتكوين كاش.",
   PleaseEnableLocationService: "الرجاء تمكين خدمة موقع الجهاز.",
   PleaseEnterNickname: "الرجاء إدخال اللقب",
   PleaseEnterOrScanEncryptionPublicKey: "الرجاء إدخال أو مسح المفتاح العام للتشفير",

--- a/src/i18n/de/index.js
+++ b/src/i18n/de/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Planname",
   Plans: "Pläne",
   PlatformFee: "Plattformgebühr",
+  PlatformFeeInfo: "Die Plattform erhebt eine Gebühr von 0,3 %, die auf einen BCH-Wert von maximal 1 USD begrenzt ist.",
   PleaseEnableLocationService: "Bitte aktivieren Sie den Standortdienst des Geräts.",
   PleaseEnterNickname: "Bitte geben Sie einen Spitznamen ein",
   PleaseEnterOrScanEncryptionPublicKey: "Bitte geben Sie den öffentlichen Verschlüsselungsschlüssel ein oder scannen Sie ihn",

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -2084,6 +2084,7 @@ export default {
   PlanURL: "Plan URL",
   Plans: "Plans",
   PlatformFee: "Platform Fee",
+  PlatformFeeInfo: "A 0.3% fee charged by the platform, capped at a maximum of 1 USD worth of BCH.",
   PleaseEnableLocationService: "Please enable device's location service.",
   PleaseEnterNickname: "Please enter nickname",
   PleaseEnterOrScanEncryptionPublicKey: "Please enter or scan the encryption public key",

--- a/src/i18n/es-ar/index.js
+++ b/src/i18n/es-ar/index.js
@@ -2027,6 +2027,7 @@ export default {
   PlanName: "Nombre del plan",
   Plans: "Planes",
   PlatformFee: "Tarifa de plataforma",
+  PlatformFeeInfo: "Una tarifa del 0,3% cobrada por la plataforma, con un límite máximo de 1 USD en BCH.",
   PleaseEnableLocationService: "Habilite el servicio de ubicación del dispositivo.",
   PleaseEnterNickname: "Por favor ingresa el apodo",
   PleaseEnterOrScanEncryptionPublicKey: "Ingrese o escanee la clave pública de cifrado",

--- a/src/i18n/es/index.js
+++ b/src/i18n/es/index.js
@@ -2027,6 +2027,7 @@ export default {
   PlanName: "Nombre del plan",
   Plans: "Planes",
   PlatformFee: "Tarifa de plataforma",
+  PlatformFeeInfo: "Una tarifa del 0,3% cobrada por la plataforma, con un límite máximo de 1 USD en BCH.",
   PleaseEnableLocationService: "Habilite el servicio de ubicación del dispositivo.",
   PleaseEnterNickname: "Por favor ingresa el apodo",
   PleaseEnterOrScanEncryptionPublicKey: "Ingrese o escanee la clave pública de cifrado",

--- a/src/i18n/fr/index.js
+++ b/src/i18n/fr/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Nom du régime",
   Plans: "Forfaits",
   PlatformFee: "Frais de plateforme",
+  PlatformFeeInfo: "Des frais de 0,3% facturés par la plateforme, plafonnés à un maximum de 1 USD de BCH.",
   PleaseEnableLocationService: "Veuillez activer le service de localisation de l'appareil.",
   PleaseEnterNickname: "Veuillez entrer votre pseudo",
   PleaseEnterOrScanEncryptionPublicKey: "Veuillez saisir ou scanner la clé publique de cryptage",

--- a/src/i18n/ha/index.js
+++ b/src/i18n/ha/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Sunan Tsari",
   Plans: "Shirye-shirye",
   PlatformFee: "Kuɗin Platform",
+  PlatformFeeInfo: "Kuɗin 0.3% da dandamali ke cajin, wanda aka ƙididdige shi a iyakar ƙimar 1 USD na BCH.",
   PleaseEnableLocationService: "Da fatan za a kunna sabis na wurin na'urar.",
   PleaseEnterNickname: "Da fatan za a shigar da sunan barkwanci",
   PleaseEnterOrScanEncryptionPublicKey: "Da fatan za a shigar da ko duba maɓallin ɓoyayyen jama'a",

--- a/src/i18n/id/index.js
+++ b/src/i18n/id/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Nama Rencana",
   Plans: "Rencana",
   PlatformFee: "Biaya Peron",
+  PlatformFeeInfo: "Biaya 0,3% dibebankan oleh platform, dibatasi maksimal BCH senilai 1 USD.",
   PleaseEnableLocationService: "Harap aktifkan layanan lokasi perangkat.",
   PleaseEnterNickname: "Silakan masukkan nama panggilan",
   PleaseEnterOrScanEncryptionPublicKey: "Silakan masukkan atau pindai kunci publik enkripsi",

--- a/src/i18n/it/index.js
+++ b/src/i18n/it/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Nome del piano",
   Plans: "Piani",
   PlatformFee: "Tariffa della piattaforma",
+  PlatformFeeInfo: "Una commissione dello 0,3% addebitata dalla piattaforma, limitata a un massimo di 1 USD in BCH.",
   PleaseEnableLocationService: "Abilita il servizio di localizzazione del dispositivo.",
   PleaseEnterNickname: "Inserisci il soprannome",
   PleaseEnterOrScanEncryptionPublicKey: "Inserisci o scansiona la chiave pubblica di crittografia",

--- a/src/i18n/ja/index.js
+++ b/src/i18n/ja/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "プラン名",
   Plans: "計画",
   PlatformFee: "プラットフォーム料金",
+  PlatformFeeInfo: "プラットフォームによって請求される 0.3% の手数料は、BCH の最大 1 米ドル相当に制限されます。",
   PleaseEnableLocationService: "デバイスの位置情報サービスを有効にしてください。",
   PleaseEnterNickname: "ニックネームを入力してください",
   PleaseEnterOrScanEncryptionPublicKey: "暗号化公開キーを入力するかスキャンしてください",

--- a/src/i18n/ko/index.js
+++ b/src/i18n/ko/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "계획 이름",
   Plans: "계획",
   PlatformFee: "플랫폼 수수료",
+  PlatformFeeInfo: "플랫폼에서 부과하는 0.3% 수수료는 최대 1 USD 상당의 BCH로 제한됩니다.",
   PleaseEnableLocationService: "기기의 위치 서비스를 활성화하세요.",
   PleaseEnterNickname: "닉네임을 입력해주세요",
   PleaseEnterOrScanEncryptionPublicKey: "암호화 공개 키를 입력하거나 스캔하세요.",

--- a/src/i18n/nl/index.js
+++ b/src/i18n/nl/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Plannaam",
   Plans: "Plannen",
   PlatformFee: "Platformkosten",
+  PlatformFeeInfo: "Er wordt een vergoeding van 0,3% in rekening gebracht door het platform, met een maximum van 1 USD aan BCH.",
   PleaseEnableLocationService: "Schakel de locatieservice van het apparaat in.",
   PleaseEnterNickname: "Voer een bijnaam in",
   PleaseEnterOrScanEncryptionPublicKey: "Voer de openbare coderingssleutel in of scan deze",

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Nome do plano",
   Plans: "Planos",
   PlatformFee: "Taxa de plataforma",
+  PlatformFeeInfo: "Uma taxa de 0,3% cobrada pela plataforma, limitada a um valor máximo de 1 USD de BCH.",
   PleaseEnableLocationService: "Ative o serviço de localização do dispositivo.",
   PleaseEnterNickname: "Por favor insira o apelido",
   PleaseEnterOrScanEncryptionPublicKey: "Por favor, insira ou digitalize a chave pública de criptografia",

--- a/src/i18n/pt/index.js
+++ b/src/i18n/pt/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Nome do plano",
   Plans: "Planos",
   PlatformFee: "Taxa de plataforma",
+  PlatformFeeInfo: "Uma taxa de 0,3% cobrada pela plataforma, limitada a um valor máximo de 1 USD de BCH.",
   PleaseEnableLocationService: "Ative o serviço de localização do dispositivo.",
   PleaseEnterNickname: "Por favor insira o apelido",
   PleaseEnterOrScanEncryptionPublicKey: "Por favor, insira ou digitalize a chave pública de criptografia",

--- a/src/i18n/ru/index.js
+++ b/src/i18n/ru/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Название плана",
   Plans: "Планы",
   PlatformFee: "Плата за платформу",
+  PlatformFeeInfo: "Платформа взимает комиссию в размере 0,3%, но не более 1 доллара США за BCH.",
   PleaseEnableLocationService: "Пожалуйста, включите службу определения местоположения устройства.",
   PleaseEnterNickname: "Пожалуйста, введите псевдоним",
   PleaseEnterOrScanEncryptionPublicKey: "Пожалуйста, введите или отсканируйте открытый ключ шифрования.",

--- a/src/i18n/tl/index.js
+++ b/src/i18n/tl/index.js
@@ -2026,6 +2026,7 @@ export default {
   PlanName: "Pangalan ng Plano",
   Plans: "Mga plano",
   PlatformFee: "Bayad sa Platform",
+  PlatformFeeInfo: "Isang 0.3% na bayad na sinisingil ng platform, na nilimitahan sa maximum na 1 USD na halaga ng BCH.",
   PleaseEnableLocationService: "Mangyaring paganahin ang serbisyo sa lokasyon ng device.",
   PleaseEnterNickname: "Pakipasok ang palayaw",
   PleaseEnterOrScanEncryptionPublicKey: "Mangyaring ipasok o i-scan ang pampublikong key ng pag-encrypt",

--- a/src/i18n/zh-cn/index.js
+++ b/src/i18n/zh-cn/index.js
@@ -2027,6 +2027,7 @@ export default {
   PlanName: "计划名称",
   Plans: "计划",
   PlatformFee: "平台费",
+  PlatformFeeInfo: "平台收取0.3%的费用，上限为价值1美元的BCH。",
   PleaseEnableLocationService: "请启用设备的定位服务。",
   PleaseEnterNickname: "请输入昵称",
   PleaseEnterOrScanEncryptionPublicKey: "请输入或扫描加密公钥",

--- a/src/i18n/zh-tw/index.js
+++ b/src/i18n/zh-tw/index.js
@@ -2027,6 +2027,7 @@ export default {
   PlanName: "計劃名稱",
   Plans: "計劃",
   PlatformFee: "平台費",
+  PlatformFeeInfo: "平台收取0.3%的費用，上限為價值1美元的BCH。",
   PleaseEnableLocationService: "請啟用設備的定位服務。",
   PleaseEnterNickname: "請輸入暱稱",
   PleaseEnterOrScanEncryptionPublicKey: "請輸入或掃描加密公鑰",

--- a/src/pages/apps/cauldron/trade.vue
+++ b/src/pages/apps/cauldron/trade.vue
@@ -257,7 +257,15 @@
                     <q-skeleton type="text" width="80px" style="height: 1.5em;" />
                   </div>
                   <div class="row items-center justify-between text-caption text-grey">
-                    <div>{{ $t('PlatformFee') }} (0.3%)</div>
+                    <div class="row items-center">
+                      <span>{{ $t('PlatformFee') }}</span>
+                      <q-icon
+                        name="info"
+                        size="16px"
+                        class="q-ml-xs cursor-pointer"
+                        @click="showPlatformFeeInfo"
+                      />
+                    </div>
                     <q-skeleton type="text" width="80px" style="height: 1.5em;" />
                   </div>
                   <div class="row items-center justify-between text-caption text-grey">
@@ -279,7 +287,15 @@
                     <div>{{ tradeFee }} BCH</div>
                   </div>
                   <div class="row items-center justify-between text-caption text-grey">
-                    <div>{{ $t('PlatformFee') }} (0.3%)</div>
+                    <div class="row items-center">
+                      <span>{{ $t('PlatformFee') }}</span>
+                      <q-icon
+                        name="info"
+                        size="16px"
+                        class="q-ml-xs cursor-pointer"
+                        @click="showPlatformFeeInfo"
+                      />
+                    </div>
                     <div>{{ platformFeeBch }} BCH</div>
                   </div>
                   <div class="row items-center justify-between text-caption text-grey">
@@ -743,14 +759,25 @@ export default defineComponent({
       return tradeFeeBch.toFixed(8);
     });
 
+    const PLATFORM_FEE_MAX_USD = 1;
+    const maxPlatformFeeSats = computed(() => {
+      const bchUsdPrice = Number($store.getters['market/getAssetPrice']('bch', 'usd'));
+      if (!bchUsdPrice || !isFinite(bchUsdPrice) || bchUsdPrice <= 0) return null;
+      return BigInt(Math.round((PLATFORM_FEE_MAX_USD / bchUsdPrice) * 10 ** 8));
+    });
+
     const platformFee = computed(() => {
       if (!tradeResult.value) return;
       const recipient = process.env.CAULDRON_PLATFORM_FEE_ADDRESS;
       if (!recipient) return;
 
+      const platformFeeCapSats = maxPlatformFeeSats.value;
+      if (platformFeeCapSats == null) return;
+
       const summary = tradeResult.value.summary
       const tradeSizeSats = (isBuyingToken.value ? summary.supply : summary.demand) - summary.trade_fee;
-      const platformFeeSats = tradeSizeSats * 3n / 1000n;
+      let platformFeeSats = tradeSizeSats * 3n / 1000n;
+      if (platformFeeSats > platformFeeCapSats) platformFeeSats = platformFeeCapSats;
       if (platformFeeSats < 546n) return;
       return { amount: platformFeeSats, to: recipient };
     })
@@ -758,6 +785,15 @@ export default defineComponent({
       if (!platformFee.value) return 0;
       return Number(platformFee.value.amount) / 10 ** 8;
     });
+
+    function showPlatformFeeInfo() {
+      $q.dialog({
+        title: $t('PlatformFee'),
+        message: $t('PlatformFeeInfo', {}, 'A 0.3% fee charged by the platform, capped at a maximum of 1 USD worth of BCH.'),
+        color: 'primary',
+        class: `text-bow ${getDarkModeClass(darkMode.value)}`,
+      })
+    }
     
     const estimateTransactionFee = computed(() => {
       if (!tradeResult.value || !selectedToken.value || !tradeResult.value.summary) return '0';
@@ -1227,6 +1263,9 @@ export default defineComponent({
 
     // Initialize on mount
     onMounted(async () => {
+      if ($store.getters['market/getAssetPrice']('bch', 'usd') == null) {
+        $store.dispatch('market/updateAssetPrices', { assetId: 'bch' })
+      }
       if (props.selectTokenId) {
         try {
           const tokens = await fetchTokensList({ token_id: props.selectTokenId });
@@ -1318,6 +1357,7 @@ export default defineComponent({
       formattedOutputAmount,
       tradeFee,
       platformFeeBch,
+      showPlatformFeeInfo,
       estimateTransactionFee,
       hasSufficientBalance,
       showInsufficientBalance,

--- a/src/pages/apps/cauldron/trade.vue
+++ b/src/pages/apps/cauldron/trade.vue
@@ -763,7 +763,7 @@ export default defineComponent({
     const maxPlatformFeeSats = computed(() => {
       const bchUsdPrice = Number($store.getters['market/getAssetPrice']('bch', 'usd'));
       if (!bchUsdPrice || !isFinite(bchUsdPrice) || bchUsdPrice <= 0) return null;
-      return BigInt(Math.round((PLATFORM_FEE_MAX_USD / bchUsdPrice) * 10 ** 8));
+      return BigInt(Math.round((PLATFORM_FEE_MAX_USD * 10 ** 8) / bchUsdPrice));
     });
 
     const platformFee = computed(() => {
@@ -1029,7 +1029,9 @@ export default defineComponent({
         return;
       }
 
-      const estimatePlatformFee = supplyingBch ? (supply * 3n / 1000n) : 0n;
+      let estimatePlatformFee = supply * 3n / 1000n;
+      const platformFeeCapSats = maxPlatformFeeSats.value;
+      if (platformFeeCapSats != null && estimatePlatformFee > platformFeeCapSats) estimatePlatformFee = platformFeeCapSats;
       const estimateTxFee = 10_000n;
       const baseSupply = supply - estimatePlatformFee - estimateTxFee;
       if (!baseSupply || baseSupply <= 0n) {


### PR DESCRIPTION
## Summary
The Cauldron swap platform fee (0.3% of trade size) is now capped at a maximum of **1 USD worth of BCH**, based on the current BCH/USD price from the market store.

## Changes
- **Fee cap** (`src/pages/apps/cauldron/trade.vue`): platform fee is now `min(0.3% of trade size, 1 USD worth of BCH)`. The cap is computed from `.getters['market/getAssetPrice']('bch', 'usd')` and updates reactively with the price.
- **Fail-closed**: if the BCH/USD price is unavailable, no platform fee is charged at all, so the 1 USD cap is always honored.
- **Price freshness**: on mount, if the BCH price is missing from the market store, the page dispatches `market/updateAssetPrices` for BCH so the cap can be applied.
- **UI**: the fee breakdown now shows just "Platform Fee" with an info icon; clicking it opens a dialog explaining the fee is 0.3%, capped at 1 USD worth of BCH.
- **i18n**: added the `PlatformFeeInfo` key to `en-us` and `__texts/phrases.js`, with translations for all supported languages.

## Behavior details
- The existing 546-sats dust minimum still applies after capping (fees below dust are skipped).
- The capped fee flows through everything that consumes the fee: summary display, total BCH fees, fee estimates, and the trade commit (fee is read from the computed at execution time).
- The send-page flow is unaffected — it only displays the pool trade fee; no platform fee is charged there.

## Testing
- Manual: open Cauldron trade, enter a large trade amount — platform fee should never exceed 1 USD worth of BCH at the current price.
- Click the info icon next to "Platform Fee" — the explanation dialog appears.
- `npm run lint`: no new errors introduced (3 pre-existing errors in trade.vue remain).